### PR TITLE
Fix parsing of ESLint reports in jest-junit format

### DIFF
--- a/__tests__/__outputs__/jest-junit-eslint.md
+++ b/__tests__/__outputs__/jest-junit-eslint.md
@@ -1,11 +1,17 @@
 ![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
+<details><summary>Expand for details</summary>
+ 
+|Report|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|fixtures/jest-junit-eslint.xml|1 ✅|||0ms|
 ## ✅ <a id="user-content-r0" href="#r0">fixtures/jest-junit-eslint.xml</a>
 **1** tests were completed in **0ms** with **1** passed, **0** failed and **0** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[test.jsx](#r0s0)|1✅|||0ms|
+|[test.jsx](#r0s0)|1 ✅|||0ms|
 ### ✅ <a id="user-content-r0s0" href="#r0s0">test.jsx</a>
 ```
 test
   ✅ test.jsx
 ```
+</details>

--- a/__tests__/__outputs__/jest-junit-eslint.md
+++ b/__tests__/__outputs__/jest-junit-eslint.md
@@ -1,0 +1,11 @@
+![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
+## ✅ <a id="user-content-r0" href="#r0">fixtures/jest-junit-eslint.xml</a>
+**1** tests were completed in **0ms** with **1** passed, **0** failed and **0** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[test.jsx](#r0s0)|1✅|||0ms|
+### ✅ <a id="user-content-r0s0" href="#r0s0">test.jsx</a>
+```
+test
+  ✅ test.jsx
+```

--- a/__tests__/__snapshots__/jest-junit.test.ts.snap
+++ b/__tests__/__snapshots__/jest-junit.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jest-junit tests parsing ESLint report without timing information works - PR #134 1`] = `
+TestRunResult {
+  "path": "fixtures/jest-junit-eslint.xml",
+  "suites": [
+    TestSuiteResult {
+      "groups": [
+        TestGroupResult {
+          "name": "test",
+          "tests": [
+            TestCaseResult {
+              "error": undefined,
+              "name": "test.jsx",
+              "result": "success",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "test.jsx",
+      "totalTime": 0,
+    },
+  ],
+  "totalTime": undefined,
+}
+`;
+
 exports[`jest-junit tests report from #235 testing react components named <ComponentName /> 1`] = `
 TestRunResult {
   "path": "fixtures/external/jest/jest-react-component-test-results.xml",

--- a/__tests__/fixtures/jest-junit-eslint.xml
+++ b/__tests__/fixtures/jest-junit-eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+<testsuite package="org.eslint" time="0" tests="1" errors="0" name="test.jsx">
+<testcase time="0" name="test.jsx" classname="test" />
+</testsuite>
+</testsuites>

--- a/__tests__/jest-junit.test.ts
+++ b/__tests__/jest-junit.test.ts
@@ -105,4 +105,24 @@ describe('jest-junit tests', () => {
     fs.mkdirSync(path.dirname(outputPath), {recursive: true})
     fs.writeFileSync(outputPath, report)
   })
+
+  it('parsing ESLint report without timing information works - PR #134', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'jest-junit-eslint.xml')
+    const outputPath = path.join(__dirname, '__outputs__', 'jest-junit-eslint.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: ['test.js']
+    }
+
+    const parser = new JestJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result])
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -1320,7 +1320,7 @@ class JestJunitParser {
                 const sr = new test_results_1.TestSuiteResult(name, this.getGroups(ts), time);
                 return sr;
             });
-        const time = parseFloat(junit.testsuites.$.time) * 1000;
+        const time = junit.testsuites.$ && parseFloat(junit.testsuites.$.time) * 1000;
         return new test_results_1.TestRunResult(path, suites, time);
     }
     getGroups(suite) {

--- a/src/parsers/jest-junit/jest-junit-parser.ts
+++ b/src/parsers/jest-junit/jest-junit-parser.ts
@@ -43,7 +43,7 @@ export class JestJunitParser implements TestParser {
             return sr
           })
 
-    const time = parseFloat(junit.testsuites.$.time) * 1000
+    const time = junit.testsuites.$ && parseFloat(junit.testsuites.$.time) * 1000
     return new TestRunResult(path, suites, time)
   }
 


### PR DESCRIPTION
The [ESLint junit formatter](https://www.npmjs.com/package/eslint-junit) does not include a total time attribute for the root `<testsuites>` element.

This PR makes the parser a little bit more lenient to accept `testsuites` elements without any attributes at all.