### PR TITLE
Update mocha-json usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,16 +290,22 @@ Configuration of `uniqueOutputName`, `suiteNameTemplate`, `classNameTemplate`, `
 - Mocha version [v7.2.0](https://github.com/mochajs/mocha/releases/tag/v7.2.0) or higher
 - Usage of [json](https://mochajs.org/#json) reporter.
 
-You can use the following example configuration in `package.json`:
+For Mocha >= [v9.1.0](https://github.com/mochajs/mocha/releases/tag/v9.1.0), you can use the following example configuration in `package.json`:
+```json
+"scripts": {
+  "test": "mocha --reporter json --reporter-option output=test-results.json"
+}
+```
+
+For Mocha < v9.1, the command should look like this:
 ```json
 "scripts": {
   "test": "mocha --reporter json > test-results.json"
 }
 ```
-
-Test processing might fail if any of your tests write anything on standard output.
-Mocha, unfortunately, doesn't have the option to store `json` output directly to the file, and we have to rely on redirecting its standard output.
-There is a work in progress to fix it: [mocha#4607](https://github.com/mochajs/mocha/pull/4607)
+Additionally, test processing might fail if any of your tests write anything on standard output.
+Before version [v9.1.0](https://github.com/mochajs/mocha/releases/tag/v9.1.0), Mocha doesn't have the option to store `json` output directly to the file, and we have to rely on redirecting its standard output ([mocha#4607](https://github.com/mochajs/mocha/pull/4607)).
+Please update Mocha to version [v9.1.0](https://github.com/mochajs/mocha/releases/tag/v9.1.0) or above if you encounter this issue.
 </details>
 
 ## GitHub limitations


### PR DESCRIPTION
With mocha#4607 fixed and published in [v9.1.0](https://github.com/mochajs/mocha/releases/tag/v9.1.0), users can output valid json using mocha's JSON reporter and the `--reporter-option output={filename}` option, provided version 9.1.0 or above is used.

This PR updates the readme to reflect this.