### PR TITLE
docs(readme): changed a broken command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ It will create test results in Junit XML format which can be then processed by t
 You can use the following example configuration in `package.json`:
 ```json
 "scripts": {
-  "test": "jest --ci --reporters=default --reporters=jest-Junit"
+  "test": "jest --ci --reporters=default --reporters=jest-junit"
 },
 "devDependencies": {
   "jest": "^26.5.3",


### PR DESCRIPTION
### fixed case sensitive issue in jest command which cause an error.
```diff
- "test": "jest --ci --reporters=default --reporters=jest-Junit"
+ "test": "jest --ci --reporters=default --reporters=jest-junit"
```

**when it happens :-**
I copied the command from readme and runned it in my project, and it says:-
```bash
Error: Could not resolve a module for a custom reporter.
  Module name: jest-Junit
```
**fixed by :-**
when I put every letters in lowercase, it worked fine!
- 'jest-<ins>**J**</ins>unit' must be 'jest-<ins>**j**</ins>unit'