### PR TITLE
fix: default-valued fields are not mandatory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
       Limits which test suites are listed. Supported options:
         - all
         - only-failed
-    required: true
+    required: false
     default: 'all'
   list-tests:
     description: |
@@ -45,17 +45,17 @@ inputs:
         - all
         - only-failed
         - none
-    required: true
+    required: false
     default: 'all'
   max-annotations:
     description: |
       Limits number of created annotations with error message and stack trace captured during test execution.
       Must be less or equal to 50.
-    required: true
+    required: false
     default: '10'
   fail-on-error:
     description: Set this action as failed if test report contain any failed test
-    required: true
+    required: false
     default: 'true'
   working-directory:
     description: Relative path under $GITHUB_WORKSPACE where the repository was checked out


### PR DESCRIPTION
Hello

Thank you for sharing this cool action.

A couple of the action fields that uses default values are also marked as required,
I keep seeing errors in my _vscode_ so I pushed this small fix.

Thanks!
:-)
