### PR TITLE
Update jest-Junit part of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ It will create test results in Junit XML format which can be then processed by t
 You can use the following example configuration in `package.json`:
 ```json
 "scripts": {
-  "test": "jest --ci --reporters=default --reporters=jest-Junit"
+  "test": "jest --ci --reporters=default --reporters=jest-junit"
 },
 "devDependencies": {
   "jest": "^26.5.3",


### PR DESCRIPTION
I had issues with setting --reporters=jest-Junit". I found I needed to use --reporters=jest-junit" instead.