### PR TITLE
Fix #199: Use ✅ instead of ✔️ for better cross platform look

### DIFF
--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -6,8 +6,8 @@ export enum Align {
 }
 
 export const Icon = {
-  skip: '✖️', // ':heavy_multiplication_x:'
-  success: '✔️', // ':heavy_check_mark:'
+  skip: '⚪', // ':white-circle:'
+  success: '✅', // ':white_check_mark:'
   fail: '❌' // ':x:'
 }
 

--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -6,7 +6,7 @@ export enum Align {
 }
 
 export const Icon = {
-  skip: '⚪', // ':white-circle:'
+  skip: '⚪', // ':white_circle:'
   success: '✅', // ':white_check_mark:'
   fail: '❌' // ':x:'
 }


### PR DESCRIPTION
- Use the ✅ for passed tests
- Use the ⚪ for skipped tests