### PR TITLE
Improve clarity on configuring for forkable repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ To workaround this security restriction, it's required to use two separate workf
 1. `CI` runs in the context of the PR head branch with the read-only token. It executes the tests and uploads test results as a build artifact
 2. `Test Report` runs in the context of the repository main branch with read/write token. It will download test results and create reports
 
+The second workflow will only run after it has been merged into your default branch (typically `main` or `master`), it won't run in a PR unless after the workflow file is part of that branch.
+
 **PR head branch:**  *.github/workflows/ci.yml*
 ```yaml
 name: 'CI'


### PR DESCRIPTION
Add a note to signify that a workflow-triggered run (needed for public forkable repos) won't execute in a PR and must be merged into `main` first.

I stumbled upon this while following the instructions here in the `readme.md` and I couldn't get the PR to show the report. The cause of that is described here: https://github.com/orgs/community/discussions/25288.

Basically: create the workflow file, merge to `main` and only then a new PR (forked or otherwise) will pick up on the added workflow.

Found while working on https://github.com/fsprojects/FSharp.Control.TaskSeq/pull/101, and that PR didn't show the changes. After merge, it did show up in https://github.com/fsprojects/FSharp.Control.TaskSeq/pull/103.