### PR TITLE
Only report failure if fail-on-error is set

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -174,7 +174,7 @@ class TestReporter {
     core.info('Creating annotations')
     const annotations = getAnnotations(results, this.maxAnnotations)
 
-    const isFailed = results.some(tr => tr.result === 'failed')
+    const isFailed = this.failOnError && results.some(tr => tr.result === 'failed')
     const conclusion = isFailed ? 'failure' : 'success'
     const icon = isFailed ? Icon.fail : Icon.success
 


### PR DESCRIPTION
The flag is checked when exiting early, but the report update at the end ignores it, causing the test run to be reported as a failure.

Fixes #161.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>