### PR TITLE
Don't fail empty results if failOnError is False

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -135,7 +135,7 @@ class TestReporter {
       return
     }
 
-    if (results.length === 0) {
+    if (this.failOnError && results.length === 0) {
       core.setFailed(`No test report files were found`)
       return
     }
@@ -179,7 +179,7 @@ class TestReporter {
     core.info('Creating annotations')
     const annotations = getAnnotations(results, this.maxAnnotations)
 
-    const isFailed = this.failOnError && results.some(tr => tr.result === 'failed')
+    const isFailed = results.some(tr => tr.result === 'failed')
     const conclusion = isFailed ? 'failure' : 'success'
     const icon = isFailed ? Icon.fail : Icon.success
 


### PR DESCRIPTION
This also changes how the check is created, failing the check on failing tests. This resolves #217 and also resolves #161.

If people would actually still like the check itself to pass on failing tests, I would recommend adding that as an additional parameter to the action (`failCheckOnFailure` ?), but I don't trust my own TS skills enough to do that. However, my guess is that #214 was a misunderstanding of what #161 wanted to do, and not many people actually want that.