### PR TITLE
docs(path): Clarify test result paths format

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ jobs:
     # Name of the Check Run which will be created
     name: ''
 
-    # Coma separated list of paths to test results
+    # The paths to test results, comma separated strings. 
     # Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
     # All matched result files must be of the same format
     path: ''


### PR DESCRIPTION
I tried arrays and some other values I've now forgotten about but this is what ended up working for me:

```
          path: >-
            ./build/*/pytest-junit.xml,
            ./build/*/prospector-xunit.xml
```