### PR TITLE
Add support for NUnit v3 XML results files

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ jobs:
 
     # Format of test results. Supported options:
     #   dart-json
+    #   dotnet-nunit
     #   dotnet-trx
     #   flutter-json
     #   java-junit

--- a/__tests__/__outputs__/dotnet-nunit.md
+++ b/__tests__/__outputs__/dotnet-nunit.md
@@ -1,0 +1,28 @@
+![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)
+## ❌ <a id="user-content-r0" href="#r0">fixtures/dotnet-nunit.xml</a>
+**9** tests were completed in **0ms** with **3** passed, **5** failed and **1** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[DotnetTests.NUnitV3Tests.dll.DotnetTests.XUnitTests](#r0s0)|3✅|5❌|1⚪|0ms|
+### ❌ <a id="user-content-r0s0" href="#r0s0">DotnetTests.NUnitV3Tests.dll.DotnetTests.XUnitTests</a>
+```
+CalculatorTests
+  ✅ Is_Even_Number(2)
+  ❌ Is_Even_Number(3)
+	  Expected: True
+	  But was:  False
+	
+  ❌ Exception_In_TargetTest
+	System.DivideByZeroException : Attempted to divide by zero.
+  ❌ Exception_In_Test
+	System.Exception : Test
+  ❌ Failing_Test
+	  Expected: 3
+	  But was:  2
+	
+  ✅ Passing_Test
+  ✅ Passing_Test_With_Description
+  ⚪ Skipped_Test
+  ❌ Timeout_Test
+	
+```

--- a/__tests__/__outputs__/dotnet-nunit.md
+++ b/__tests__/__outputs__/dotnet-nunit.md
@@ -1,9 +1,9 @@
 ![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)
 ## ❌ <a id="user-content-r0" href="#r0">fixtures/dotnet-nunit.xml</a>
-**9** tests were completed in **0ms** with **3** passed, **5** failed and **1** skipped.
+**9** tests were completed in **230ms** with **3** passed, **5** failed and **1** skipped.
 |Test suite|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
-|[DotnetTests.NUnitV3Tests.dll.DotnetTests.XUnitTests](#r0s0)|3✅|5❌|1⚪|0ms|
+|[DotnetTests.NUnitV3Tests.dll.DotnetTests.XUnitTests](#r0s0)|3✅|5❌|1⚪|69ms|
 ### ❌ <a id="user-content-r0s0" href="#r0s0">DotnetTests.NUnitV3Tests.dll.DotnetTests.XUnitTests</a>
 ```
 CalculatorTests

--- a/__tests__/__snapshots__/dotnet-nunit.test.ts.snap
+++ b/__tests__/__snapshots__/dotnet-nunit.test.ts.snap
@@ -13,7 +13,7 @@ TestRunResult {
               "error": undefined,
               "name": "Is_Even_Number(2)",
               "result": "success",
-              "time": 0.000622,
+              "time": 0.622,
             },
             TestCaseResult {
               "error": Object {
@@ -27,7 +27,7 @@ TestRunResult {
               },
               "name": "Is_Even_Number(3)",
               "result": "failed",
-              "time": 0.001098,
+              "time": 1.098,
             },
             TestCaseResult {
               "error": Object {
@@ -39,7 +39,7 @@ TestRunResult {
               },
               "name": "Exception_In_TargetTest",
               "result": "failed",
-              "time": 0.022805,
+              "time": 22.805,
             },
             TestCaseResult {
               "error": Object {
@@ -50,7 +50,7 @@ TestRunResult {
               },
               "name": "Exception_In_Test",
               "result": "failed",
-              "time": 0.000528,
+              "time": 0.528,
             },
             TestCaseResult {
               "error": Object {
@@ -64,25 +64,25 @@ TestRunResult {
               },
               "name": "Failing_Test",
               "result": "failed",
-              "time": 0.028162,
+              "time": 28.162,
             },
             TestCaseResult {
               "error": undefined,
               "name": "Passing_Test",
               "result": "success",
-              "time": 0.000238,
+              "time": 0.23800000000000002,
             },
             TestCaseResult {
               "error": undefined,
               "name": "Passing_Test_With_Description",
               "result": "success",
-              "time": 0.000135,
+              "time": 0.135,
             },
             TestCaseResult {
               "error": undefined,
               "name": "Skipped_Test",
               "result": "skipped",
-              "time": 0.000398,
+              "time": 0.398,
             },
             TestCaseResult {
               "error": Object {
@@ -93,7 +93,7 @@ TestRunResult {
               },
               "name": "Timeout_Test",
               "result": "failed",
-              "time": 0.014949,
+              "time": 14.949,
             },
           ],
         },
@@ -102,6 +102,6 @@ TestRunResult {
       "totalTime": undefined,
     },
   ],
-  "totalTime": 0.230308,
+  "totalTime": 230.30800000000002,
 }
 `;

--- a/__tests__/__snapshots__/dotnet-nunit.test.ts.snap
+++ b/__tests__/__snapshots__/dotnet-nunit.test.ts.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dotnet-nunit tests report from ./reports/dotnet test results matches snapshot 1`] = `
+TestRunResult {
+  "path": "fixtures/dotnet-nunit.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "CalculatorTests",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "Is_Even_Number(2)",
+              "result": "success",
+              "time": 0.000622,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 61
+",
+                "line": undefined,
+                "message": "  Expected: True
+  But was:  False
+",
+                "path": undefined,
+              },
+              "name": "Is_Even_Number(3)",
+              "result": "failed",
+              "time": 0.001098,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.Unit\\\\Calculator.cs:line 9
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 33",
+                "line": undefined,
+                "message": "System.DivideByZeroException : Attempted to divide by zero.",
+                "path": undefined,
+              },
+              "name": "Exception_In_TargetTest",
+              "result": "failed",
+              "time": 0.022805,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 39",
+                "line": undefined,
+                "message": "System.Exception : Test",
+                "path": undefined,
+              },
+              "name": "Exception_In_Test",
+              "result": "failed",
+              "time": 0.000528,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 27
+",
+                "line": undefined,
+                "message": "  Expected: 3
+  But was:  2
+",
+                "path": undefined,
+              },
+              "name": "Failing_Test",
+              "result": "failed",
+              "time": 0.028162,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Passing_Test",
+              "result": "success",
+              "time": 0.000238,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Passing_Test_With_Description",
+              "result": "success",
+              "time": 0.000135,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "Skipped_Test",
+              "result": "skipped",
+              "time": 0.000398,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": "",
+                "line": undefined,
+                "message": "",
+                "path": undefined,
+              },
+              "name": "Timeout_Test",
+              "result": "failed",
+              "time": 0.014949,
+            },
+          ],
+        },
+      ],
+      "name": "DotnetTests.NUnitV3Tests.dll.DotnetTests.XUnitTests",
+      "totalTime": undefined,
+    },
+  ],
+  "totalTime": 0.230308,
+}
+`;

--- a/__tests__/__snapshots__/dotnet-nunit.test.ts.snap
+++ b/__tests__/__snapshots__/dotnet-nunit.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`dotnet-nunit tests report from ./reports/dotnet test results matches snapshot 1`] = `
 TestRunResult {
   "path": "fixtures/dotnet-nunit.xml",
-  "suites": Array [
+  "suites": [
     TestSuiteResult {
-      "groups": Array [
+      "groups": [
         TestGroupResult {
           "name": "CalculatorTests",
-          "tests": Array [
+          "tests": [
             TestCaseResult {
               "error": undefined,
               "name": "Is_Even_Number(2)",
@@ -16,8 +16,8 @@ TestRunResult {
               "time": 0.622,
             },
             TestCaseResult {
-              "error": Object {
-                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 61
+              "error": {
+                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.NUnitV3Tests\\CalculatorTests.cs:line 61
 ",
                 "line": undefined,
                 "message": "  Expected: True
@@ -30,9 +30,9 @@ TestRunResult {
               "time": 1.098,
             },
             TestCaseResult {
-              "error": Object {
-                "details": "   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.Unit\\\\Calculator.cs:line 9
-   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 33",
+              "error": {
+                "details": "   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.Unit\\Calculator.cs:line 9
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.NUnitV3Tests\\CalculatorTests.cs:line 33",
                 "line": undefined,
                 "message": "System.DivideByZeroException : Attempted to divide by zero.",
                 "path": undefined,
@@ -42,8 +42,8 @@ TestRunResult {
               "time": 22.805,
             },
             TestCaseResult {
-              "error": Object {
-                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 39",
+              "error": {
+                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.NUnitV3Tests\\CalculatorTests.cs:line 39",
                 "line": undefined,
                 "message": "System.Exception : Test",
                 "path": undefined,
@@ -53,8 +53,8 @@ TestRunResult {
               "time": 0.528,
             },
             TestCaseResult {
-              "error": Object {
-                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\\\\Users\\\\Michal\\\\Workspace\\\\dorny\\\\test-reporter\\\\reports\\\\dotnet\\\\DotnetTests.NUnitV3Tests\\\\CalculatorTests.cs:line 27
+              "error": {
+                "details": "   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.NUnitV3Tests\\CalculatorTests.cs:line 27
 ",
                 "line": undefined,
                 "message": "  Expected: 3
@@ -85,7 +85,7 @@ TestRunResult {
               "time": 0.398,
             },
             TestCaseResult {
-              "error": Object {
+              "error": {
                 "details": "",
                 "line": undefined,
                 "message": "",

--- a/__tests__/dotnet-nunit.test.ts
+++ b/__tests__/dotnet-nunit.test.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+import {DotNetNunitParser} from '../src/parsers/dotnet-nunit/dotnet-nunit-parser'
+import {ParseOptions} from '../src/test-parser'
+import {getReport} from '../src/report/get-report'
+import {normalizeFilePath} from '../src/utils/path-utils'
+
+describe('dotnet-nunit tests', () => {
+  it('report from ./reports/dotnet test results matches snapshot', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'dotnet-nunit.xml')
+    const outputPath = path.join(__dirname, '__outputs__', 'dotnet-nunit.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: ['DotnetTests.Unit/Calculator.cs', 'DotnetTests.NUnitV3Tests/CalculatorTests.cs']
+    }
+
+    const parser = new DotNetNunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result])
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+})

--- a/__tests__/dotnet-nunit.test.ts
+++ b/__tests__/dotnet-nunit.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-import {DotNetNunitParser} from '../src/parsers/dotnet-nunit/dotnet-nunit-parser'
+import {DotnetNunitParser} from '../src/parsers/dotnet-nunit/dotnet-nunit-parser'
 import {ParseOptions} from '../src/test-parser'
 import {getReport} from '../src/report/get-report'
 import {normalizeFilePath} from '../src/utils/path-utils'
@@ -18,7 +18,7 @@ describe('dotnet-nunit tests', () => {
       trackedFiles: ['DotnetTests.Unit/Calculator.cs', 'DotnetTests.NUnitV3Tests/CalculatorTests.cs']
     }
 
-    const parser = new DotNetNunitParser(opts)
+    const parser = new DotnetNunitParser(opts)
     const result = await parser.parse(filePath, fileContent)
     expect(result).toMatchSnapshot()
 

--- a/__tests__/fixtures/dotnet-nunit.xml
+++ b/__tests__/fixtures/dotnet-nunit.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-run id="0" runstate="Runnable" testcasecount="9" result="Failed" total="9" passed="3" failed="5" inconclusive="0" skipped="1" asserts="5" engine-version="3.12.0.0" clr-version="3.1.16" start-time="2021-06-28 20:23:41Z" end-time="2021-06-28 20:23:41Z" duration="0.230308">
+  <command-line><![CDATA[C:\Users\Michal\.dotnet\tools\.store\nunit.consolerunner.netcore\3.12.0-beta2\nunit.consolerunner.netcore\3.12.0-beta2\tools\netcoreapp3.1\any\nunit3-console.dll reports/dotnet/DotnetTests.NUnitV3Tests/bin/Debug/netcoreapp3.1/DotnetTests.NUnitV3Tests.dll --result=__tests__/fixtures/dotnet-nunit.xml]]></command-line>
+  <test-suite type="Assembly" id="1-1011" name="DotnetTests.NUnitV3Tests.dll" fullname="C:/Users/Michal/Workspace/dorny/test-reporter/reports/dotnet/DotnetTests.NUnitV3Tests/bin/Debug/netcoreapp3.1/DotnetTests.NUnitV3Tests.dll" runstate="Runnable" testcasecount="9" result="Failed" site="Child" start-time="2021-06-28T20:23:41.4594179Z" end-time="2021-06-28T20:23:41.5420313Z" duration="0.082553" total="9" passed="3" failed="5" warnings="0" inconclusive="0" skipped="1" asserts="5">
+    <environment framework-version="3.13.2.0" clr-version="3.1.16" os-version="Microsoft Windows 10.0.19041" platform="Win32NT" cwd="C:\Users\Michal\Workspace\dorny\test-reporter" machine-name="DORNY-PC" user="Michal" user-domain="DORNY-PC" culture="sk-SK" uiculture="en-US" os-architecture="x64" />
+    <settings>
+      <setting name="DisposeRunners" value="True" />
+      <setting name="WorkDirectory" value="C:\Users\Michal\Workspace\dorny\test-reporter" />
+      <setting name="NumberOfTestWorkers" value="4" />
+    </settings>
+    <properties>
+      <property name="_PID" value="30996" />
+      <property name="_APPDOMAIN" value="nunit3-console" />
+    </properties>
+    <failure>
+      <message><![CDATA[One or more child tests had errors]]></message>
+    </failure>
+    <test-suite type="TestSuite" id="1-1012" name="DotnetTests" fullname="DotnetTests" runstate="Runnable" testcasecount="9" result="Failed" site="Child" start-time="2021-06-28T20:23:41.4647482Z" end-time="2021-06-28T20:23:41.5420271Z" duration="0.077277" total="9" passed="3" failed="5" warnings="0" inconclusive="0" skipped="1" asserts="5">
+      <failure>
+        <message><![CDATA[One or more child tests had errors]]></message>
+      </failure>
+      <test-suite type="TestSuite" id="1-1013" name="XUnitTests" fullname="DotnetTests.XUnitTests" runstate="Runnable" testcasecount="9" result="Failed" site="Child" start-time="2021-06-28T20:23:41.4649710Z" end-time="2021-06-28T20:23:41.5420231Z" duration="0.077053" total="9" passed="3" failed="5" warnings="0" inconclusive="0" skipped="1" asserts="5">
+        <failure>
+          <message><![CDATA[One or more child tests had errors]]></message>
+        </failure>
+        <test-suite type="TestFixture" id="1-1000" name="CalculatorTests" fullname="DotnetTests.XUnitTests.CalculatorTests" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" testcasecount="9" result="Failed" site="Child" start-time="2021-06-28T20:23:41.4661195Z" end-time="2021-06-28T20:23:41.5420143Z" duration="0.075896" total="9" passed="3" failed="5" warnings="0" inconclusive="0" skipped="1" asserts="5">
+          <failure>
+            <message><![CDATA[One or more child tests had errors]]></message>
+          </failure>
+          <test-case id="1-1004" name="Exception_In_TargetTest" fullname="DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest" methodname="Exception_In_TargetTest" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="2033520428" result="Failed" label="Error" start-time="2021-06-28T20:23:41.4684284Z" end-time="2021-06-28T20:23:41.4911288Z" duration="0.022805" asserts="0">
+            <failure>
+              <message><![CDATA[System.DivideByZeroException : Attempted to divide by zero.]]></message>
+              <stack-trace><![CDATA[   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.Unit\Calculator.cs:line 9
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.NUnitV3Tests\CalculatorTests.cs:line 33]]></stack-trace>
+            </failure>
+          </test-case>
+          <test-case id="1-1005" name="Exception_In_Test" fullname="DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test" methodname="Exception_In_Test" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="145176317" result="Failed" label="Error" start-time="2021-06-28T20:23:41.4930398Z" end-time="2021-06-28T20:23:41.4935666Z" duration="0.000528" asserts="0">
+            <failure>
+              <message><![CDATA[System.Exception : Test]]></message>
+              <stack-trace><![CDATA[   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.NUnitV3Tests\CalculatorTests.cs:line 39]]></stack-trace>
+            </failure>
+          </test-case>
+          <test-case id="1-1003" name="Failing_Test" fullname="DotnetTests.XUnitTests.CalculatorTests.Failing_Test" methodname="Failing_Test" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="189717168" result="Failed" start-time="2021-06-28T20:23:41.4935910Z" end-time="2021-06-28T20:23:41.5217516Z" duration="0.028162" asserts="1">
+            <failure>
+              <message><![CDATA[  Expected: 3
+  But was:  2
+]]></message>
+              <stack-trace><![CDATA[   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.NUnitV3Tests\CalculatorTests.cs:line 27
+]]></stack-trace>
+            </failure>
+            <assertions>
+              <assertion result="Failed">
+                <message><![CDATA[  Expected: 3
+  But was:  2
+]]></message>
+                <stack-trace><![CDATA[   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.NUnitV3Tests\CalculatorTests.cs:line 27
+]]></stack-trace>
+              </assertion>
+            </assertions>
+          </test-case>
+          <test-suite type="Theory" id="1-1010" name="Is_Even_Number" fullname="DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2021-06-28T20:23:41.5217837Z" end-time="2021-06-28T20:23:41.5251025Z" duration="0.003318" total="2" passed="1" failed="1" warnings="0" inconclusive="0" skipped="0" asserts="2">
+            <properties>
+              <property name="_JOINTYPE" value="Combinatorial" />
+            </properties>
+            <failure>
+              <message><![CDATA[One or more child tests had errors]]></message>
+            </failure>
+            <test-case id="1-1008" name="Is_Even_Number(2)" fullname="DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(2)" methodname="Is_Even_Number" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="2002556739" result="Passed" start-time="2021-06-28T20:23:41.5222381Z" end-time="2021-06-28T20:23:41.5228607Z" duration="0.000622" asserts="1" />
+            <test-case id="1-1009" name="Is_Even_Number(3)" fullname="DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(3)" methodname="Is_Even_Number" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="1722214143" result="Failed" start-time="2021-06-28T20:23:41.5228803Z" end-time="2021-06-28T20:23:41.5239781Z" duration="0.001098" asserts="1">
+              <failure>
+                <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                <stack-trace><![CDATA[   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.NUnitV3Tests\CalculatorTests.cs:line 61
+]]></stack-trace>
+              </failure>
+              <assertions>
+                <assertion result="Failed">
+                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                  <stack-trace><![CDATA[   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.NUnitV3Tests\CalculatorTests.cs:line 61
+]]></stack-trace>
+                </assertion>
+              </assertions>
+            </test-case>
+          </test-suite>
+          <test-case id="1-1001" name="Passing_Test" fullname="DotnetTests.XUnitTests.CalculatorTests.Passing_Test" methodname="Passing_Test" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="550330290" result="Passed" start-time="2021-06-28T20:23:41.5260365Z" end-time="2021-06-28T20:23:41.5262756Z" duration="0.000238" asserts="1" />
+          <test-case id="1-1002" name="Passing_Test_With_Description" fullname="DotnetTests.XUnitTests.CalculatorTests.Passing_Test_With_Description" methodname="Passing_Test_With_Description" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="1693317298" result="Passed" start-time="2021-06-28T20:23:41.5263998Z" end-time="2021-06-28T20:23:41.5265354Z" duration="0.000135" asserts="1">
+            <properties>
+              <property name="Description" value="Some description" />
+            </properties>
+          </test-case>
+          <test-case id="1-1007" name="Skipped_Test" fullname="DotnetTests.XUnitTests.CalculatorTests.Skipped_Test" methodname="Skipped_Test" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Ignored" seed="1512653931" result="Skipped" label="Ignored" start-time="2021-06-28T20:23:41.5265550Z" end-time="2021-06-28T20:23:41.5269525Z" duration="0.000398" asserts="0">
+            <properties>
+              <property name="_SKIPREASON" value="Skipped" />
+            </properties>
+            <reason>
+              <message><![CDATA[Skipped]]></message>
+            </reason>
+          </test-case>
+          <test-case id="1-1006" name="Timeout_Test" fullname="DotnetTests.XUnitTests.CalculatorTests.Timeout_Test" methodname="Timeout_Test" classname="DotnetTests.XUnitTests.CalculatorTests" runstate="Runnable" seed="258810529" result="Failed" label="Test exceeded Timeout value 1ms." start-time="2021-06-28T20:23:41.5269651Z" end-time="2021-06-28T20:23:41.5419118Z" duration="0.014949" asserts="0">
+            <properties>
+              <property name="Timeout" value="1" />
+            </properties>
+            <failure />
+          </test-case>
+        </test-suite>
+      </test-suite>
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/__tests__/fixtures/external/nunit-sample.xml
+++ b/__tests__/fixtures/external/nunit-sample.xml
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-run id="2" name="mock-assembly.dll" fullname="D:\Dev\NUnit\nunit-3.0\work\bin\vs2008\Debug\mock-assembly.dll" testcasecount="25" result="Failed" time="0.154" total="18" passed="12" failed="2" inconclusive="1" skipped="3" asserts="2" run-date="2011-07-26" start-time="11:34:27">
+  <environment nunit-version="1.0.0.0" clr-version="2.0.50727.4961" os-version="Microsoft Windows NT 6.1.7600.0" platform="Win32NT" cwd="D:\Dev\NUnit\nunit-3.0\work\bin\vs2008\Debug" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" culture="en-US" uiculture="en-US" />
+  <test-suite type="Assembly" id="1036" name="mock-assembly.dll" fullname="D:\Dev\NUnit\nunit-3.0\work\bin\vs2008\Debug\mock-assembly.dll" testcasecount="25" result="Failed" time="0.154" total="18" passed="12" failed="2" inconclusive="1" skipped="3" asserts="2">
+    <properties>
+      <property name="_PID" value="11928" />
+      <property name="_APPDOMAIN" value="test-domain-mock-assembly.dll" />
+    </properties>
+    <failure>
+      <message><![CDATA[Child test failed]]></message>
+    </failure>
+    <test-suite type="TestFixture" id="1000" name="MockTestFixture" fullname="NUnit.Tests.Assemblies.MockTestFixture" testcasecount="11" result="Failed" time="0.119" total="10" passed="4" failed="2" inconclusive="1" skipped="3" asserts="0">
+      <properties>
+        <property name="Category" value="FixtureCategory" />
+        <property name="Description" value="Fake Test Fixture" />
+      </properties>
+      <failure>
+        <message><![CDATA[Child test failed]]></message>
+      </failure>
+      <test-case id="1005" name="FailingTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.FailingTest" result="Failed" time="0.023" asserts="0">
+        <failure>
+          <message><![CDATA[Intentional failure]]></message>
+          <stack-trace><![CDATA[   at NUnit.Framework.Assert.Fail(String message, Object[] args) in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\framework\Assert.cs:line 142
+   at NUnit.Framework.Assert.Fail(String message) in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\framework\Assert.cs:line 152
+   at NUnit.Tests.Assemblies.MockTestFixture.FailingTest() in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\mock-assembly\MockAssembly.cs:line 121]]></stack-trace>
+        </failure>
+      </test-case>
+      <test-case id="1010" name="InconclusiveTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.InconclusiveTest" result="Inconclusive" time="0.001" asserts="0" />
+      <test-case id="1001" name="MockTest1" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest1" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="Description" value="Mock Test #1" />
+        </properties>
+      </test-case>
+      <test-case id="1002" name="MockTest2" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest2" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="Severity" value="Critical" />
+          <property name="Description" value="This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description" />
+          <property name="Category" value="MockCategory" />
+        </properties>
+      </test-case>
+      <test-case id="1003" name="MockTest3" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest3" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="Category" value="AnotherCategory" />
+          <property name="Category" value="MockCategory" />
+        </properties>
+      </test-case>
+      <test-case id="1007" name="MockTest4" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest4" result="Skipped" label="Ignored" time="0.000" asserts="0">
+        <properties>
+          <property name="Category" value="Foo" />
+          <property name="_SKIPREASON" value="ignoring this test method for now" />
+        </properties>
+        <reason>
+          <message><![CDATA[ignoring this test method for now]]></message>
+        </reason>
+      </test-case>
+      <test-case id="1004" name="MockTest5" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest5" result="Skipped" label="Invalid" time="0.000" asserts="0">
+        <properties>
+          <property name="_SKIPREASON" value="Method is not public" />
+        </properties>
+        <reason>
+          <message><![CDATA[Method is not public]]></message>
+        </reason>
+      </test-case>
+      <test-case id="1009" name="NotRunnableTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest" result="Skipped" label="Invalid" time="0.000" asserts="0">
+        <properties>
+          <property name="_SKIPREASON" value="No arguments were provided" />
+        </properties>
+        <reason>
+          <message><![CDATA[No arguments were provided]]></message>
+        </reason>
+      </test-case>
+      <test-case id="1011" name="TestWithException" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithException" result="Failed" label="Error" time="0.002" asserts="0">
+        <failure>
+          <message><![CDATA[System.ApplicationException : Intentional Exception]]></message>
+          <stack-trace><![CDATA[   at NUnit.Tests.Assemblies.MockTestFixture.MethodThrowsException() in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\mock-assembly\MockAssembly.cs:line 158
+   at NUnit.Tests.Assemblies.MockTestFixture.TestWithException() in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\mock-assembly\MockAssembly.cs:line 153]]></stack-trace>
+        </failure>
+      </test-case>
+      <test-case id="1006" name="TestWithManyProperties" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithManyProperties" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="TargetMethod" value="SomeClassName" />
+          <property name="Size" value="5" />
+        </properties>
+      </test-case>
+    </test-suite>
+    <test-suite type="TestFixture" id="1023" name="BadFixture" fullname="NUnit.Tests.BadFixture" testcasecount="1" result="Skipped" label="Invalid" time="0.000" total="0" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_SKIPREASON" value="No suitable constructor was found" />
+      </properties>
+      <reason>
+        <message><![CDATA[No suitable constructor was found]]></message>
+      </reason>
+    </test-suite>
+    <test-suite type="TestFixture" id="1025" name="FixtureWithTestCases" fullname="NUnit.Tests.FixtureWithTestCases" testcasecount="2" result="Passed" time="0.010" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="2">
+      <test-suite type="ParameterizedMethod" id="1026" name="MethodWithParameters" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters" testcasecount="2" result="Passed" time="0.009" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="2">
+        <test-case id="1027" name="MethodWithParameters(2,2)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(2,2)" result="Passed" time="0.006" asserts="1" />
+        <test-case id="1028" name="MethodWithParameters(9,11)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)" result="Passed" time="0.000" asserts="1" />
+      </test-suite>
+    </test-suite>
+    <test-suite type="TestFixture" id="1016" name="IgnoredFixture" fullname="NUnit.Tests.IgnoredFixture" testcasecount="3" result="Skipped" label="Ignored" time="0.000" total="0" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_SKIPREASON" value="" />
+      </properties>
+      <reason>
+        <message><![CDATA[]]></message>
+      </reason>
+    </test-suite>
+    <test-suite type="ParameterizedFixture" id="1029" name="ParameterizedFixture" fullname="NUnit.Tests.ParameterizedFixture" testcasecount="4" result="Passed" time="0.007" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-suite type="TestFixture" id="1030" name="ParameterizedFixture(42)" fullname="NUnit.Tests.ParameterizedFixture(42)" testcasecount="2" result="Passed" time="0.003" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <test-case id="1031" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(42).Test1" result="Passed" time="0.000" asserts="0" />
+        <test-case id="1032" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(42).Test2" result="Passed" time="0.000" asserts="0" />
+      </test-suite>
+      <test-suite type="TestFixture" id="1033" name="ParameterizedFixture(5)" fullname="NUnit.Tests.ParameterizedFixture(5)" testcasecount="2" result="Passed" time="0.002" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <test-case id="1034" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(5).Test1" result="Passed" time="0.000" asserts="0" />
+        <test-case id="1035" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(5).Test2" result="Passed" time="0.000" asserts="0" />
+      </test-suite>
+    </test-suite>
+    <test-suite type="TestFixture" id="1012" name="OneTestCase" fullname="NUnit.Tests.Singletons.OneTestCase" testcasecount="1" result="Passed" time="0.001" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-case id="1013" name="TestCase" fullname="NUnit.Tests.Singletons.OneTestCase.TestCase" result="Passed" time="0.000" asserts="0" />
+    </test-suite>
+    <test-suite type="TestFixture" id="1014" name="MockTestFixture" fullname="NUnit.Tests.TestAssembly.MockTestFixture" testcasecount="1" result="Passed" time="0.001" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-case id="1015" name="MyTest" fullname="NUnit.Tests.TestAssembly.MockTestFixture.MyTest" result="Passed" time="0.001" asserts="0" />
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ inputs:
     description: |
       Format of test results. Supported options:
         - dart-json
+        - dotnet-nunit
         - dotnet-trx
         - flutter-json
         - java-junit

--- a/dist/index.js
+++ b/dist/index.js
@@ -427,7 +427,7 @@ class TestReporter {
             case 'dart-json':
                 return new dart_json_parser_1.DartJsonParser(options, 'dart');
             case 'dotnet-nunit':
-                return new dotnet_nunit_parser_1.DotNetNunitParser(options);
+                return new dotnet_nunit_parser_1.DotnetNunitParser(options);
             case 'dotnet-trx':
                 return new dotnet_trx_parser_1.DotnetTrxParser(options);
             case 'flutter-json':
@@ -742,12 +742,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DotNetNunitParser = void 0;
+exports.DotnetNunitParser = void 0;
 const xml2js_1 = __nccwpck_require__(6189);
 const node_utils_1 = __nccwpck_require__(5824);
 const path_utils_1 = __nccwpck_require__(4070);
 const test_results_1 = __nccwpck_require__(2768);
-class DotNetNunitParser {
+class DotnetNunitParser {
     constructor(options) {
         this.options = options;
     }
@@ -852,7 +852,7 @@ class DotNetNunitParser {
         return ((_b = (_a = this.options.workDir) !== null && _a !== void 0 ? _a : this.assumedWorkDir) !== null && _b !== void 0 ? _b : (this.assumedWorkDir = (0, path_utils_1.getBasePath)(path, this.options.trackedFiles)));
     }
 }
-exports.DotNetNunitParser = DotNetNunitParser;
+exports.DotnetNunitParser = DotnetNunitParser;
 
 
 /***/ }),

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test",
     "dart-fixture": "cd \"reports/dart\" && dart test --file-reporter=\"json:../../__tests__/fixtures/dart-json.json\"",
     "dotnet-fixture": "dotnet test reports/dotnet/DotnetTests.XUnitTests --logger \"trx;LogFileName=../../../../__tests__/fixtures/dotnet-trx.trx\"",
+    "dotnet-nunit-fixture": "nunit.exe reports/dotnet/DotnetTests.NUnitV3Tests/bin/Debug/netcoreapp3.1/DotnetTests.NUnitV3Tests.dll --result=__tests__/fixtures/dotnet-nunit.xml",
     "jest-fixture": "cd \"reports/jest\" && npm test",
     "mocha-fixture": "cd \"reports/mocha\" && npm test"
   },

--- a/reports/dotnet/DotnetTests.NUnitV3Tests/CalculatorTests.cs
+++ b/reports/dotnet/DotnetTests.NUnitV3Tests/CalculatorTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using DotnetTests.Unit;
+using NUnit.Framework;
+
+namespace DotnetTests.XUnitTests
+{
+    public class CalculatorTests
+    {
+        private readonly Calculator _calculator = new Calculator();                
+
+        [Test]
+        public void Passing_Test()
+        {
+            Assert.That(_calculator.Sum(1, 1), Is.EqualTo(2));
+        }
+
+        [Test(Description = "Some description")]
+        public void Passing_Test_With_Description()
+        {
+            Assert.That(2, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Failing_Test()
+        {
+            Assert.That(_calculator.Sum(1, 1), Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Exception_In_TargetTest()
+        {
+            _calculator.Div(1, 0);
+        }
+
+        [Test]
+        public void Exception_In_Test()
+        {
+            throw new Exception("Test");
+        }
+
+        [Test]
+        [Timeout(1)]
+        public void Timeout_Test()
+        {
+            Thread.Sleep(100);
+        }
+
+        [Test]
+        [Ignore("Skipped")]
+        public void Skipped_Test()
+        {
+            throw new Exception("Test");
+        }
+
+        [Theory]        
+        [TestCase(2)]
+        [TestCase(3)]
+        public void Is_Even_Number(int i)
+        {
+            Assert.True(i % 2 == 0);
+        }
+    }
+}

--- a/reports/dotnet/DotnetTests.NUnitV3Tests/DotnetTests.NUnitV3Tests.csproj
+++ b/reports/dotnet/DotnetTests.NUnitV3Tests/DotnetTests.NUnitV3Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetTests.Unit\DotnetTests.Unit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/reports/dotnet/DotnetTests.sln
+++ b/reports/dotnet/DotnetTests.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{BCAC3B31
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotnetTests.XUnitTests", "DotnetTests.XUnitTests\DotnetTests.XUnitTests.csproj", "{F8607EDB-D25D-47AA-8132-38ACA242E845}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetTests.NUnitV3Tests", "DotnetTests.NUnitV3Tests\DotnetTests.NUnitV3Tests.csproj", "{81023ED7-56CB-47E9-86C5-9125A0873C55}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,12 +25,17 @@ Global
 		{F8607EDB-D25D-47AA-8132-38ACA242E845}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8607EDB-D25D-47AA-8132-38ACA242E845}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8607EDB-D25D-47AA-8132-38ACA242E845}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81023ED7-56CB-47E9-86C5-9125A0873C55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81023ED7-56CB-47E9-86C5-9125A0873C55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81023ED7-56CB-47E9-86C5-9125A0873C55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81023ED7-56CB-47E9-86C5-9125A0873C55}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F8607EDB-D25D-47AA-8132-38ACA242E845} = {BCAC3B31-ADB1-4221-9D5B-182EE868648C}
+		{81023ED7-56CB-47E9-86C5-9125A0873C55} = {BCAC3B31-ADB1-4221-9D5B-182EE868648C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6ED5543C-74AA-4B21-8050-943550F3F66E}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {getAnnotations} from './report/get-annotations'
 import {getReport} from './report/get-report'
 
 import {DartJsonParser} from './parsers/dart-json/dart-json-parser'
+import {DotNetNunitParser} from './parsers/dotnet-nunit/dotnet-nunit-parser'
 import {DotnetTrxParser} from './parsers/dotnet-trx/dotnet-trx-parser'
 import {JavaJunitParser} from './parsers/java-junit/java-junit-parser'
 import {JestJunitParser} from './parsers/jest-junit/jest-junit-parser'
@@ -214,6 +215,8 @@ class TestReporter {
     switch (reporter) {
       case 'dart-json':
         return new DartJsonParser(options, 'dart')
+      case 'dotnet-nunit':
+        return new DotNetNunitParser(options)
       case 'dotnet-trx':
         return new DotnetTrxParser(options)
       case 'flutter-json':

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import {getAnnotations} from './report/get-annotations'
 import {getReport} from './report/get-report'
 
 import {DartJsonParser} from './parsers/dart-json/dart-json-parser'
-import {DotNetNunitParser} from './parsers/dotnet-nunit/dotnet-nunit-parser'
+import {DotnetNunitParser} from './parsers/dotnet-nunit/dotnet-nunit-parser'
 import {DotnetTrxParser} from './parsers/dotnet-trx/dotnet-trx-parser'
 import {JavaJunitParser} from './parsers/java-junit/java-junit-parser'
 import {JestJunitParser} from './parsers/jest-junit/jest-junit-parser'
@@ -216,7 +216,7 @@ class TestReporter {
       case 'dart-json':
         return new DartJsonParser(options, 'dart')
       case 'dotnet-nunit':
-        return new DotNetNunitParser(options)
+        return new DotnetNunitParser(options)
       case 'dotnet-trx':
         return new DotnetTrxParser(options)
       case 'flutter-json':

--- a/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
@@ -34,7 +34,7 @@ export class DotNetNunitParser implements TestParser {
 
   private getTestRunResult(path: string, nunit: NunitReport): TestRunResult {
     const suites: TestSuiteResult[] = []
-    const time = parseFloat(nunit['test-run'].$.duration)
+    const time = parseFloat(nunit['test-run'].$.duration) * 1000
 
     this.populateTestCasesRecursive(suites, [], nunit['test-run']['test-suite'])
 
@@ -93,7 +93,7 @@ export class DotNetNunitParser implements TestParser {
       new TestCaseResult(
         testCase.$.name,
         this.getTestExecutionResult(testCase),
-        parseFloat(testCase.$.duration),
+        parseFloat(testCase.$.duration) * 1000,
         this.getTestCaseError(testCase)
       )
     )

--- a/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
@@ -1,7 +1,7 @@
 import {ParseOptions, TestParser} from '../../test-parser'
 import {parseStringPromise} from 'xml2js'
 
-import {NunitReport, TestCase, TestRun, TestSuite} from './dotnet-nunit-types'
+import {NunitReport, TestCase, TestSuite} from './dotnet-nunit-types'
 import {getExceptionSource} from '../../utils/node-utils'
 import {getBasePath, normalizeFilePath} from '../../utils/path-utils'
 
@@ -50,23 +50,23 @@ export class DotNetNunitParser implements TestParser {
       return
     }
 
-    testSuites.forEach(suite => {
+    for (const suite of testSuites) {
       suitePath.push(suite)
 
       this.populateTestCasesRecursive(result, suitePath, suite['test-suite'])
 
       const testcases = suite['test-case']
       if (testcases !== undefined) {
-        testcases.forEach(testcase => {
+        for (const testcase of testcases) {
           this.addTestCase(result, suitePath, testcase)
-        })
+        }
       }
 
       suitePath.pop()
-    })
+    }
   }
 
-  private addTestCase(result: TestSuiteResult[], suitePath: TestSuite[], testCase: TestCase) {
+  private addTestCase(result: TestSuiteResult[], suitePath: TestSuite[], testCase: TestCase): void {
     // The last suite in the suite path is the "group".
     // The rest are concatenated together to form the "suite".
     // But ignore "Theory" suites.
@@ -125,8 +125,8 @@ export class DotNetNunitParser implements TestParser {
     }
 
     return {
-      path: path,
-      line: line,
+      path,
+      line,
       message: details.message && details.message.length > 0 ? details.message[0] : '',
       details: details['stack-trace'] && details['stack-trace'].length > 0 ? details['stack-trace'][0] : ''
     }

--- a/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
@@ -1,0 +1,151 @@
+import {ParseOptions, TestParser} from '../../test-parser'
+import {parseStringPromise} from 'xml2js'
+
+import {NunitReport, TestCase, TestRun, TestSuite} from './dotnet-nunit-types'
+import {getExceptionSource} from '../../utils/node-utils'
+import {getBasePath, normalizeFilePath} from '../../utils/path-utils'
+
+import {
+  TestExecutionResult,
+  TestRunResult,
+  TestSuiteResult,
+  TestGroupResult,
+  TestCaseResult,
+  TestCaseError
+} from '../../test-results'
+
+export class DotNetNunitParser implements TestParser {
+  assumedWorkDir: string | undefined
+
+  constructor(readonly options: ParseOptions) {}
+
+  async parse(path: string, content: string): Promise<TestRunResult> {
+    const ju = await this.getNunitReport(path, content)
+    return this.getTestRunResult(path, ju)
+  }
+
+  private async getNunitReport(path: string, content: string): Promise<NunitReport> {
+    try {
+      return (await parseStringPromise(content)) as NunitReport
+    } catch (e) {
+      throw new Error(`Invalid XML at ${path}\n\n${e}`)
+    }
+  }
+
+  private getTestRunResult(path: string, nunit: NunitReport): TestRunResult {
+    const suites: TestSuiteResult[] = []
+    const time = parseFloat(nunit['test-run'].$.duration)
+
+    this.populateTestCasesRecursive(suites, [], nunit['test-run']['test-suite'])
+
+    return new TestRunResult(path, suites, time)
+  }
+
+  private populateTestCasesRecursive(
+    result: TestSuiteResult[],
+    suitePath: TestSuite[],
+    testSuites: TestSuite[] | undefined
+  ): void {
+    if (testSuites === undefined) {
+      return
+    }
+
+    testSuites.forEach(suite => {
+      suitePath.push(suite)
+
+      this.populateTestCasesRecursive(result, suitePath, suite['test-suite'])
+
+      const testcases = suite['test-case']
+      if (testcases !== undefined) {
+        testcases.forEach(testcase => {
+          this.addTestCase(result, suitePath, testcase)
+        })
+      }
+
+      suitePath.pop()
+    })
+  }
+
+  private addTestCase(result: TestSuiteResult[], suitePath: TestSuite[], testCase: TestCase) {
+    // The last suite in the suite path is the "group".
+    // The rest are concatenated together to form the "suite".
+    // But ignore "Theory" suites.
+    const suitesWithoutTheories = suitePath.filter(suite => suite.$.type !== 'Theory')
+    const suiteName = suitesWithoutTheories
+      .slice(0, suitesWithoutTheories.length - 1)
+      .map(suite => suite.$.name)
+      .join('.')
+    const groupName = suitesWithoutTheories[suitesWithoutTheories.length - 1].$.name
+
+    let existingSuite = result.find(existingSuite => existingSuite.name === suiteName)
+    if (existingSuite === undefined) {
+      existingSuite = new TestSuiteResult(suiteName, [])
+      result.push(existingSuite)
+    }
+
+    let existingGroup = existingSuite.groups.find(existingGroup => existingGroup.name === groupName)
+    if (existingGroup === undefined) {
+      existingGroup = new TestGroupResult(groupName, [])
+      existingSuite.groups.push(existingGroup)
+    }
+
+    existingGroup.tests.push(
+      new TestCaseResult(
+        testCase.$.name,
+        this.getTestExecutionResult(testCase),
+        parseFloat(testCase.$.duration),
+        this.getTestCaseError(testCase)
+      )
+    )
+  }
+
+  private getTestExecutionResult(test: TestCase): TestExecutionResult {
+    if (test.$.result === 'Failed' || test.failure) return 'failed'
+    if (test.$.result === 'Skipped') return 'skipped'
+    return 'success'
+  }
+
+  private getTestCaseError(tc: TestCase): TestCaseError | undefined {
+    if (!this.options.parseErrors || !tc.failure || tc.failure.length === 0) {
+      return undefined
+    }
+
+    const details = tc.failure[0]
+    let path
+    let line
+
+    if (details['stack-trace'] !== undefined && details['stack-trace'].length > 0) {
+      const src = getExceptionSource(details['stack-trace'][0], this.options.trackedFiles, file =>
+        this.getRelativePath(file)
+      )
+      if (src) {
+        path = src.path
+        line = src.line
+      }
+    }
+
+    return {
+      path: path,
+      line: line,
+      message: details.message && details.message.length > 0 ? details.message[0] : '',
+      details: details['stack-trace'] && details['stack-trace'].length > 0 ? details['stack-trace'][0] : ''
+    }
+  }
+
+  private getRelativePath(path: string): string {
+    path = normalizeFilePath(path)
+    const workDir = this.getWorkDir(path)
+    if (workDir !== undefined && path.startsWith(workDir)) {
+      path = path.substr(workDir.length)
+    }
+    return path
+  }
+
+  private getWorkDir(path: string): string | undefined {
+    return (
+      this.options.workDir ??
+      this.assumedWorkDir ??
+      (this.assumedWorkDir = getBasePath(path, this.options.trackedFiles))
+    )
+  }
+}

--- a/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
@@ -14,7 +14,7 @@ import {
   TestCaseError
 } from '../../test-results'
 
-export class DotNetNunitParser implements TestParser {
+export class DotnetNunitParser implements TestParser {
   assumedWorkDir: string | undefined
 
   constructor(readonly options: ParseOptions) {}

--- a/src/parsers/dotnet-nunit/dotnet-nunit-types.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-types.ts
@@ -1,5 +1,5 @@
 export interface NunitReport {
-  "test-run": TestRun
+  'test-run': TestRun
 }
 
 export interface TestRun {

--- a/src/parsers/dotnet-nunit/dotnet-nunit-types.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-types.ts
@@ -1,0 +1,57 @@
+export interface NunitReport {
+  "test-run": TestRun
+}
+
+export interface TestRun {
+  $: {
+    id: string
+    runstate: string
+    testcasecount: string
+    result: string
+    total: string
+    passed: string
+    failed: string
+    inconclusive: string
+    skipped: string
+    asserts: string
+    'engine-version': string
+    'clr-version': string
+    'start-time': string
+    'end-time': string
+    duration: string
+  }
+  'test-suite'?: TestSuite[]
+}
+
+export interface TestSuite {
+  $: {
+    name: string
+    type: string
+  }
+  'test-case'?: TestCase[]
+  'test-suite'?: TestSuite[]
+}
+
+export interface TestCase {
+  $: {
+    id: string
+    name: string
+    fullname: string
+    methodname: string
+    classname: string
+    runstate: string
+    seed: string
+    result: string
+    label: string
+    'start-time': string
+    'end-time': string
+    duration: string
+    asserts: string
+  }
+  failure?: TestFailure[]
+}
+
+export interface TestFailure {
+  message?: string[]
+  'stack-trace'?: string[]
+}

--- a/src/parsers/rspec-json/rspec-json-parser.ts
+++ b/src/parsers/rspec-json/rspec-json-parser.ts
@@ -1,4 +1,3 @@
-import { Console } from 'console'
 import {ParseOptions, TestParser} from '../../test-parser'
 import {
   TestCaseError,

--- a/src/parsers/rspec-json/rspec-json-types.ts
+++ b/src/parsers/rspec-json/rspec-json-types.ts
@@ -17,7 +17,7 @@ export interface RspecExample {
   exception?: RspecException
 }
 
-type TestStatus = 'passed' | 'failed' | 'pending';
+type TestStatus = 'passed' | 'failed' | 'pending'
 
 export interface RspecException {
   class: string


### PR DESCRIPTION
This is important for displaying the results generated by the Unity Test Framework, among probably other uses. It builds on the work started in the https://github.com/dorny/test-reporter/tree/dotnet-nunit branch.

I struggled a little bit with how to translate the format's arbitrarily-nested suites to the test-reporter's suite, group, test structure. In the end I made the last suite before the test case the "group", and flattened any suites above that into a single suite. Except that it ignores suites of type "Theory". So basically test fixtures (classes) will be groups, and assemblies/projects will be suites. Other things are definitely possible.

Fixes #98