### PR TITLE
feat: support pytest JUnit XML format

### DIFF
--- a/__tests__/fixtures/external/pytest/pytest-single-case.xml
+++ b/__tests__/fixtures/external/pytest/pytest-single-case.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+    <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="0.178"
+               timestamp="2023-03-08T11:47:09.377238" hostname="0e634555ad5c">
+        <testcase classname="product_changes.tests.first_test.MyTestCase" name="test_something" time="0.133"/>
+    </testsuite>
+</testsuites>

--- a/__tests__/pytest-junit.test.ts
+++ b/__tests__/pytest-junit.test.ts
@@ -1,15 +1,15 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
-import { JestJunitParser } from '../src/parsers/jest-junit/jest-junit-parser'
-import { ParseOptions } from '../src/test-parser'
-import { normalizeFilePath } from '../src/utils/path-utils'
+import {JestJunitParser} from '../src/parsers/jest-junit/jest-junit-parser'
+import {ParseOptions} from '../src/test-parser'
+import {normalizeFilePath} from '../src/utils/path-utils'
 
 describe('pytest-junit tests', () => {
   it('test with one successful test', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'external', 'pytest', 'pytest-single-case.xml')
     const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
-    const fileContent = fs.readFileSync(fixturePath, { encoding: 'utf8' })
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
 
     const opts: ParseOptions = {
       parseErrors: true,

--- a/__tests__/pytest-junit.test.ts
+++ b/__tests__/pytest-junit.test.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { JestJunitParser } from '../src/parsers/jest-junit/jest-junit-parser'
+import { ParseOptions } from '../src/test-parser'
+import { normalizeFilePath } from '../src/utils/path-utils'
+
+describe('pytest-junit tests', () => {
+  it('test with one successful test', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'pytest', 'pytest-single-case.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, { encoding: 'utf8' })
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new JestJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result.tests).toBe(1)
+    expect(result.result).toBe('success')
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -1211,7 +1211,9 @@ class JestJunitParser {
                 const sr = new test_results_1.TestSuiteResult(name, this.getGroups(ts), time);
                 return sr;
             });
-        const time = parseFloat(junit.testsuites.$.time) * 1000;
+        const time = junit.testsuites.$ === undefined
+            ? suites.reduce((sum, suite) => sum + suite.time, 0)
+            : parseFloat(junit.testsuites.$.time) * 1000;
         return new test_results_1.TestRunResult(path, suites, time);
     }
     getGroups(suite) {

--- a/src/parsers/jest-junit/jest-junit-parser.ts
+++ b/src/parsers/jest-junit/jest-junit-parser.ts
@@ -33,7 +33,7 @@ export class JestJunitParser implements TestParser {
   }
 
   private getTestRunResult(path: string, junit: JunitReport): TestRunResult {
-    const suites =
+    const suites: TestSuiteResult[] =
       junit.testsuites.testsuite === undefined
         ? []
         : junit.testsuites.testsuite.map(ts => {
@@ -43,7 +43,11 @@ export class JestJunitParser implements TestParser {
             return sr
           })
 
-    const time = parseFloat(junit.testsuites.$.time) * 1000
+    const time =
+      junit.testsuites.$ === undefined
+        ? suites.reduce((sum, suite) => sum + suite.time, 0)
+        : parseFloat(junit.testsuites.$.time) * 1000
+
     return new TestRunResult(path, suites, time)
   }
 

--- a/src/parsers/jest-junit/jest-junit-types.ts
+++ b/src/parsers/jest-junit/jest-junit-types.ts
@@ -3,7 +3,7 @@ export interface JunitReport {
 }
 
 export interface TestSuites {
-  $: {
+  $?: {
     time: string
   }
   testsuite?: TestSuite[]


### PR DESCRIPTION
Support the JUnit XML format that is generated by `pytest`:
https://docs.pytest.org/en/latest/how-to/output.html#creating-junitxml-format-files