### PR TITLE
Not every failure has a stack trace.

### DIFF
--- a/src/utils/parse-utils.ts
+++ b/src/utils/parse-utils.ts
@@ -19,6 +19,6 @@ export function parseIsoDate(str: string): Date {
 }
 
 export function getFirstNonEmptyLine(stackTrace: string): string | undefined {
-  const lines = stackTrace.split(/\r?\n/g)
-  return lines.find(str => !/^\s*$/.test(str))
+  const lines = stackTrace?.split(/\r?\n/g)
+  return lines?.find(str => !/^\s*$/.test(str))
 }


### PR DESCRIPTION
Failures without stack traces resulted in
` ##[error]TypeError: Cannot read properties of undefined (reading 'spilt')`