### PR TITLE
add feature fail-on-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ jobs:
     # Set action as failed if test report contains any failed test
     fail-on-error: 'true'
 
+    # Set this action as failed if no test results were found
+    fail-on-empty: 'true'
+
     # Relative path under $GITHUB_WORKSPACE where the repository was checked out.
     working-directory: ''
 

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
     description: Set this action as failed if test report contain any failed test
     required: true
     default: 'true'
+  fail-on-empty:
+    description: Set this action as failed if no test results were found
+    required: true
+    default: 'true'
   working-directory:
     description: Relative path under $GITHUB_WORKSPACE where the repository was checked out
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -293,6 +293,7 @@ class TestReporter {
         this.listTests = core.getInput('list-tests', { required: true });
         this.maxAnnotations = parseInt(core.getInput('max-annotations', { required: true }));
         this.failOnError = core.getInput('fail-on-error', { required: true }) === 'true';
+        this.failOnEmpty = core.getInput('fail-on-empty', { required: true }) === 'true';
         this.workDirInput = core.getInput('working-directory', { required: false });
         this.onlySummary = core.getInput('only-summary', { required: false }) === 'true';
         this.token = core.getInput('token', { required: true });
@@ -364,7 +365,7 @@ class TestReporter {
                 core.setFailed(`Failed test were found and 'fail-on-error' option is set to ${this.failOnError}`);
                 return;
             }
-            if (results.length === 0) {
+            if (results.length === 0 && this.failOnEmpty) {
                 core.setFailed(`No test report files were found`);
                 return;
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ class TestReporter {
   readonly listTests = core.getInput('list-tests', {required: true}) as 'all' | 'failed' | 'none'
   readonly maxAnnotations = parseInt(core.getInput('max-annotations', {required: true}))
   readonly failOnError = core.getInput('fail-on-error', {required: true}) === 'true'
+  readonly failOnEmpty = core.getInput('fail-on-empty', {required: true}) === 'true'
   readonly workDirInput = core.getInput('working-directory', {required: false})
   readonly onlySummary = core.getInput('only-summary', {required: false}) === 'true'
   readonly token = core.getInput('token', {required: true})
@@ -135,7 +136,7 @@ class TestReporter {
       return
     }
 
-    if (results.length === 0) {
+    if (results.length === 0 && this.failOnEmpty) {
       core.setFailed(`No test report files were found`)
       return
     }


### PR DESCRIPTION
There are use-cases where you wouldn't necessarily want the action to fail if no test results were found (it could just mean that no test results were run). This PR supports not failing the job if no results are found.