### PR TITLE
🪲 fixed "Error: TypeError: Cannot read properties of undefined (readi…

### DIFF
--- a/__tests__/__snapshots__/java-junit.test.ts.snap
+++ b/__tests__/__snapshots__/java-junit.test.ts.snap
@@ -6878,3 +6878,57 @@ at java.lang.Thread.run(Thread.java:748)
   "totalTime": 2126531.0000000005,
 }
 `;
+
+exports[`java-junit tests report from jest in junit format 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/test-report-jest.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "MaintenanceFilterComponent",
+          "tests": Array [
+            TestCaseResult {
+              "error": Object {
+                "details": undefined,
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "should create",
+              "result": "failed",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "maintenance/maintenance-filter/maintenance-filter.component.spec.ts",
+      "totalTime": 1204,
+    },
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "AppComponent",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "should create the app",
+              "result": "success",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "should forward to login page",
+              "result": "success",
+              "time": 0,
+            },
+          ],
+        },
+      ],
+      "name": "app.component.spec.ts",
+      "totalTime": 1244,
+    },
+  ],
+  "totalTime": undefined,
+}
+`;

--- a/__tests__/fixtures/external/java/test-report-jest.xml
+++ b/__tests__/fixtures/external/java/test-report-jest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite id="0" name="maintenance/maintenance-filter/maintenance-filter.component.spec.ts" errors="0" package="maintenance-filter.component.spec.ts" hostname="localhost" tests="1" failures="1" time="1.204" timestamp="2023-05-22T13:04:47">
+    <properties>
+    </properties>
+    <testcase classname="MaintenanceFilterComponent" name="should create" time="0">
+      <failure message="NullInjectorError: R3InjectorError(DynamicTestModule)[InjectionToken L10N_LOCALE -&gt; InjectionToken L10N_LOCALE]: 
+  NullInjectorError: No provider for InjectionToken L10N_LOCALE!
+    at processTicksAndRejections (node:internal/process/task_queues:96:5)" type="AssertionError">
+      </failure>
+    </testcase>
+    <system-out/>
+    <system-err/>
+  </testsuite>
+  <testsuite id="1" name="app.component.spec.ts" errors="0" package="app.component.spec.ts" hostname="localhost" tests="2" failures="0" time="1.244" timestamp="2023-05-22T13:04:47">
+    <properties>
+    </properties>
+    <testcase classname="AppComponent" name="should create the app" time="0">
+    </testcase>
+    <testcase classname="AppComponent" name="should forward to login page" time="0">
+    </testcase>
+    <system-out/>
+    <system-err/>
+  </testsuite>
+</testsuites>

--- a/__tests__/java-junit.test.ts
+++ b/__tests__/java-junit.test.ts
@@ -73,6 +73,28 @@ describe('java-junit tests', () => {
     fs.writeFileSync(outputPath, report)
   })
 
+  it('report from jest in junit format', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'test-report-jest.xml')
+    const trackedFilesPath = path.join(__dirname, 'fixtures', 'external', 'java', 'files.txt')
+    const outputPath = path.join(__dirname, '__outputs__', 'pulsar-test-results.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const trackedFiles = fs.readFileSync(trackedFilesPath, {encoding: 'utf8'}).split(/\n\r?/g)
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result])
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+
   it('parses empty failures in test results', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'empty_failures.xml')
     const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))

--- a/src/utils/parse-utils.ts
+++ b/src/utils/parse-utils.ts
@@ -19,6 +19,6 @@ export function parseIsoDate(str: string): Date {
 }
 
 export function getFirstNonEmptyLine(stackTrace: string): string | undefined {
-  const lines = stackTrace.split(/\r?\n/g)
+  const lines = stackTrace ? stackTrace.split(/\r?\n/g) : []
   return lines.find(str => !/^\s*$/.test(str))
 }


### PR DESCRIPTION
…ng 'split')" if failure element is empty