### PR TITLE
Correct typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ jobs:
     # Name of the Check Run which will be created
     name: ''
 
-    # Coma separated list of paths to test results
+    # Comma-separated list of paths to test results
     # Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
     # All matched result files must be of the same format
     path: ''

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
   path:
     description: |
-      Coma separated list of paths to test results
+      Comma-separated list of paths to test results
       Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
       All matched result files must be of same format
     required: true


### PR DESCRIPTION
"Coma separated" -> "Comma-separated"