### PR TITLE
Avoid split on undefined

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2195,8 +2195,8 @@ function parseIsoDate(str) {
 }
 exports.parseIsoDate = parseIsoDate;
 function getFirstNonEmptyLine(stackTrace) {
-    const lines = stackTrace.split(/\r?\n/g);
-    return lines.find(str => !/^\s*$/.test(str));
+    const lines = stackTrace === null || stackTrace === void 0 ? void 0 : stackTrace.split(/\r?\n/g);
+    return lines === null || lines === void 0 ? void 0 : lines.find(str => !/^\s*$/.test(str));
 }
 exports.getFirstNonEmptyLine = getFirstNonEmptyLine;
 

--- a/src/utils/parse-utils.ts
+++ b/src/utils/parse-utils.ts
@@ -19,6 +19,6 @@ export function parseIsoDate(str: string): Date {
 }
 
 export function getFirstNonEmptyLine(stackTrace: string): string | undefined {
-  const lines = stackTrace.split(/\r?\n/g)
-  return lines.find(str => !/^\s*$/.test(str))
+  const lines = stackTrace?.split(/\r?\n/g)
+  return lines?.find(str => !/^\s*$/.test(str))
 }


### PR DESCRIPTION
Some reports don't include a stack trace or details on the failure.
This can happen, for example, for junit reports that are used with non Java tests or when subtests are used. See https://github.com/dorny/test-reporter/issues/256 https://github.com/dorny/test-reporter/issues/241 or https://github.com/dorny/test-reporter/issues/239 (there may be others)

Just ignore the stacktrace if it is not defined.