### PR TITLE
declare 'url' and 'url_html' as action outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,10 @@ outputs:
     description: Count of skipped tests
   time:
     description: Test execution time [ms]
+  url:
+    description: Check run URL
+  url_html:
+    description: Check run URL HTML
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
It seems the outputs `url` and `url_html` had not been declared in 2868c9aa28a8542fae47110cb1354b76612dd485 as action outputs.

In my runs, both outputs are not available.