### PR TITLE
Add `SwiftXunitParser` class based on `JavaJunitParser` for `swift-xunit` reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This [Github Action](https://github.com/features/actions) displays test results 
 - Flutter / [test](https://pub.dev/packages/test)
 - Java / [JUnit](https://junit.org/)
 - JavaScript / [JEST](https://jestjs.io/) / [Mocha](https://mochajs.org/)
+- Swift / xUnit
 
 For more information see [Supported formats](#supported-formats) section.
 
@@ -315,6 +316,12 @@ You can use the following example configuration in `package.json`:
 Test processing might fail if any of your tests write anything on standard output.
 Mocha, unfortunately, doesn't have the option to store `json` output directly to the file, and we have to rely on redirecting its standard output.
 There is a work in progress to fix it: [mocha#4607](https://github.com/mochajs/mocha/pull/4607)
+</details>
+
+<details>
+  <summary>swift-xunit (Experimental)</summary>
+
+Support for Swift test results in xUnit format is experimental - should work but it was not extensively tested.
 </details>
 
 ## GitHub limitations

--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -1,0 +1,13 @@
+![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)
+## ❌ <a id="user-content-r0" href="#r0">fixtures/swift-xunit.xml</a>
+**3** tests were completed in **220ms** with **2** passed, **1** failed and **0** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[TestResults](#r0s0)|2✅|1❌||220ms|
+### ❌ <a id="user-content-r0s0" href="#r0s0">TestResults</a>
+```
+AcmeLibTests.AcmeLibTests
+  ✅ test_always_pass
+  ✅ test_always_skip
+  ❌ test_always_fail
+```

--- a/__tests__/__snapshots__/swift-xunit.test.ts.snap
+++ b/__tests__/__snapshots__/swift-xunit.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`swift-xunit tests report from swift test results matches snapshot 1`] = `
+TestRunResult {
+  "path": "fixtures/swift-xunit.xml",
+  "suites": Array [
+    TestSuiteResult {
+      "groups": Array [
+        TestGroupResult {
+          "name": "AcmeLibTests.AcmeLibTests",
+          "tests": Array [
+            TestCaseResult {
+              "error": undefined,
+              "name": "test_always_pass",
+              "result": "success",
+              "time": 36.386333,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "test_always_skip",
+              "result": "success",
+              "time": 92.039167,
+            },
+            TestCaseResult {
+              "error": Object {
+                "details": undefined,
+                "line": undefined,
+                "message": undefined,
+                "path": undefined,
+              },
+              "name": "test_always_fail",
+              "result": "failed",
+              "time": 92.05175,
+            },
+          ],
+        },
+      ],
+      "name": "TestResults",
+      "totalTime": 220.47725000000003,
+    },
+  ],
+  "totalTime": undefined,
+}
+`;

--- a/__tests__/fixtures/swift-xunit.xml
+++ b/__tests__/fixtures/swift-xunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+<testsuite name="TestResults" errors="0" tests="3" failures="1" time="0.22047725">
+<testcase classname="AcmeLibTests.AcmeLibTests" name="test_always_pass" time="0.036386333">
+</testcase>
+<testcase classname="AcmeLibTests.AcmeLibTests" name="test_always_skip" time="0.092039167">
+</testcase>
+<testcase classname="AcmeLibTests.AcmeLibTests" name="test_always_fail" time="0.09205175">
+<failure message="failed"></failure>
+</testcase>
+</testsuite>
+</testsuites>

--- a/__tests__/swift-xunit.test.ts
+++ b/__tests__/swift-xunit.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+import {SwiftXunitParser} from '../src/parsers/swift-xunit/swift-xunit-parser'
+import {ParseOptions} from '../src/test-parser'
+import {getReport} from '../src/report/get-report'
+import {normalizeFilePath} from '../src/utils/path-utils'
+
+describe('swift-xunit tests', () => {
+  it('report from swift test results matches snapshot', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'swift-xunit.xml')
+    const outputPath = path.join(__dirname, '__outputs__', 'swift-xunit.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const trackedFiles = [
+      'Package.swift',
+      'Sources/AcmeLib/AcmeLib.swift',
+      'Tests/AcmeLibTests/AcmeLibTests.swift',
+    ]
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles
+    }
+
+    const parser = new SwiftXunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result])
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,7 @@ inputs:
         - java-junit
         - jest-junit
         - mocha-json
+        - swift-xunit
     required: true
   list-suites:
     description: |

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {DotnetTrxParser} from './parsers/dotnet-trx/dotnet-trx-parser'
 import {JavaJunitParser} from './parsers/java-junit/java-junit-parser'
 import {JestJunitParser} from './parsers/jest-junit/jest-junit-parser'
 import {MochaJsonParser} from './parsers/mocha-json/mocha-json-parser'
+import {SwiftXunitParser} from './parsers/swift-xunit/swift-xunit-parser'
 
 import {normalizeDirPath, normalizeFilePath} from './utils/path-utils'
 import {getCheckRunContext} from './utils/github-utils'
@@ -219,6 +220,8 @@ class TestReporter {
         return new JestJunitParser(options)
       case 'mocha-json':
         return new MochaJsonParser(options)
+      case 'swift-xunit':
+        return new SwiftXunitParser(options)
       default:
         throw new Error(`Input variable 'reporter' is set to invalid value '${reporter}'`)
     }

--- a/src/parsers/swift-xunit/swift-xunit-parser.ts
+++ b/src/parsers/swift-xunit/swift-xunit-parser.ts
@@ -1,0 +1,8 @@
+import {ParseOptions} from '../../test-parser'
+import {JavaJunitParser} from '../java-junit/java-junit-parser'
+
+export class SwiftXunitParser extends JavaJunitParser {
+  constructor(readonly options: ParseOptions) {
+    super(options)
+  }
+}


### PR DESCRIPTION
The Swift tests results file is in xUnit format which is compatible with the `JavaJunitParser`.