### PR TITLE
Adding runs all reporters in CI

### DIFF
--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-
+    - run : ls -all ./__tests__/fixtures/
     - uses: ./
       with:
         artifact: ${{ matrix.reporter }}

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx ]
+        reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx, java-junit ]
         include:
           - reporter: jest-junit
             path: ./__tests__/fixtures/jest-junit.xml
@@ -30,10 +30,12 @@ jobs:
             path: ./__tests__/fixtures/dart-json.json
           - reporter: dotnet-trx
             path: ./__tests__/fixtures/dotnet-trx.trx
+          - reporter: java-junit
+            path: ./__tests__/fixtures/external/pulsar-test-report.xml
 
     steps:
     - uses: actions/checkout@v4
-    - run : ls -all ./__tests__/fixtures/
+
     - uses: ./
       with:
         name: ${{ matrix.reporter }} report

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -29,7 +29,7 @@ jobs:
           - reporter: dart-json
             path: ./__tests__/fixtures/dart-json.json
           - reporter: dotnet-trx
-            path: ./__tests__/fixtures/dotnet-trx.xml
+            path: ./__tests__/fixtures/dotnet-trx.trx
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -1,0 +1,39 @@
+name: Test Report
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore: [ '**.md' ]
+  push:
+    paths-ignore: [ '**.md' ]
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  reports:
+    strategy:
+      matrix:
+        reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx ]
+        include:
+          - reporter: jest-junit
+            path: __tests__/fixtures/jest-junit.xml
+          - reporter: mocha-json
+            path: __tests__/fixtures/mocha-json.json
+          - reporter: swift-xunit
+            path: __tests__/fixtures/swift-xunit.xml
+          - reporter: dart-json
+            path: __tests__/fixtures/dart-json.json
+          - reporter: dotnet-trx
+            path: __tests__/fixtures/dotnet-trx.xml
+    name: Workflow test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./
+      with:
+        artifact: ${{ matrix.reporter }}
+        name: ${{ matrix.reporter }}
+        path: ${{ matrix.path }}
+        reporter: ${{ matrix.reporter }}

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx, java-junit ]
+        reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx, java-junit, flutter-json ]
         include:
           - reporter: jest-junit
             path: ./__tests__/fixtures/jest-junit.xml
@@ -32,6 +32,8 @@ jobs:
             path: ./__tests__/fixtures/dotnet-trx.trx
           - reporter: java-junit
             path: ./__tests__/fixtures/external/java/pulsar-test-report.xml
+          - reporter: flutter-json
+            path: ./__tests__/fixtures/external/flutter/provider-test-results.json
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -39,3 +39,4 @@ jobs:
         name: ${{ matrix.reporter }}
         path: ${{ matrix.path }}
         reporter: ${{ matrix.reporter }}
+        fail-on-error: false

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -1,4 +1,4 @@
-name: Run report
+name: Run all reports
 
 on:
   pull_request:
@@ -13,6 +13,9 @@ on:
 
 jobs:
   reports:
+    name: Run
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
         reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx ]
@@ -27,14 +30,12 @@ jobs:
             path: ./__tests__/fixtures/dart-json.json
           - reporter: dotnet-trx
             path: ./__tests__/fixtures/dotnet-trx.xml
-    name: Run
-    runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v4
     - run : ls -all ./__tests__/fixtures/
     - uses: ./
       with:
-        artifact: ${{ matrix.reporter }}
         name: ${{ matrix.reporter }}
         path: ${{ matrix.path }}
         reporter: ${{ matrix.reporter }}

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -31,7 +31,7 @@ jobs:
           - reporter: dotnet-trx
             path: ./__tests__/fixtures/dotnet-trx.trx
           - reporter: java-junit
-            path: ./__tests__/fixtures/external/pulsar-test-report.xml
+            path: ./__tests__/fixtures/external/java/pulsar-test-report.xml
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -36,7 +36,7 @@ jobs:
     - run : ls -all ./__tests__/fixtures/
     - uses: ./
       with:
-        name: ${{ matrix.reporter }}
+        name: ${{ matrix.reporter }} report
         path: ${{ matrix.path }}
         reporter: ${{ matrix.reporter }}
         fail-on-error: false

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -1,4 +1,4 @@
-name: Test Report
+name: Run report
 
 on:
   pull_request:
@@ -18,19 +18,20 @@ jobs:
         reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx ]
         include:
           - reporter: jest-junit
-            path: __tests__/fixtures/jest-junit.xml
+            path: ./__tests__/fixtures/jest-junit.xml
           - reporter: mocha-json
-            path: __tests__/fixtures/mocha-json.json
+            path: ./__tests__/fixtures/mocha-json.json
           - reporter: swift-xunit
-            path: __tests__/fixtures/swift-xunit.xml
+            path: ./__tests__/fixtures/swift-xunit.xml
           - reporter: dart-json
-            path: __tests__/fixtures/dart-json.json
+            path: ./__tests__/fixtures/dart-json.json
           - reporter: dotnet-trx
-            path: __tests__/fixtures/dotnet-trx.xml
-    name: Workflow test
+            path: ./__tests__/fixtures/dotnet-trx.xml
+    name: Run
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - uses: ./
       with:
         artifact: ${{ matrix.reporter }}

--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -4,12 +4,15 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore: [ '**.md' ]
+    paths-ignore: ['**.md']
   push:
-    paths-ignore: [ '**.md' ]
+    paths-ignore: ['**.md']
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   reports:
@@ -18,7 +21,22 @@ jobs:
 
     strategy:
       matrix:
-        reporter: [ jest-junit, mocha-json, swift-xunit, dart-json, dotnet-trx, java-junit, flutter-json ]
+        reporter:
+          [
+            jest-junit,
+            mocha-json,
+            swift-xunit,
+            dart-json,
+            dotnet-trx,
+            java-junit,
+            flutter-json,
+            dotnet-nunit,
+            golang-json,
+            tester-junit,
+            phpunit-junit,
+            python-xunit,
+            rspec-json
+          ]
         include:
           - reporter: jest-junit
             path: ./__tests__/fixtures/jest-junit.xml
@@ -34,9 +52,21 @@ jobs:
             path: ./__tests__/fixtures/external/java/pulsar-test-report.xml
           - reporter: flutter-json
             path: ./__tests__/fixtures/external/flutter/provider-test-results.json
+          - reporter: dotnet-nunit
+            path: ./__tests__/fixtures/dotnet-nunit.xml
+          - reporter: golang-json
+            path: ./__tests__/fixtures/golang-json.json
+          - reporter: tester-junit
+            path: ./__tests__/fixtures/nette-tester/tester-v1.7-report.xml
+          - reporter: phpunit-junit
+            path: ./__tests__/fixtures/phpunit/phpunit.xml
+          - reporter: python-xunit
+            path: ./__tests__/fixtures/python-xunit-pytest.xml
+          - reporter: rspec-json
+            path: ./__tests__/fixtures/rspec-json.json
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - uses: ./
       with:


### PR DESCRIPTION
The goal of this evolution is adding examples for all available reporters.

Supported reporters:

- [X] jest-junit
- [X] mocha-json
- [X] swift-xunit
- [X] dart-json
- [X] dotnet-trx
- [X] java-junit
- [x] flutter-json
