### PR TITLE
Merge v1.7.0 release to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "test-check",
-  "version": "0.0.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "test-check",
-      "version": "0.0.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
     "package": "ncc build --license licenses.txt && eolConverter lf 'dist/*'",
+    "version": "npm run build && npm run package && git add dist/*",
     "test": "jest --ci --reporters=default --reporters=jest-junit",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test",
     "dart-fixture": "cd \"reports/dart\" && dart test --file-reporter=\"json:../../__tests__/fixtures/dart-json.json\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-check",
-  "version": "0.0.0",
+  "version": "1.7.0",
   "private": true,
   "description": "Presents test results from popular testing frameworks as Github check run",
   "main": "lib/main.js",


### PR DESCRIPTION
Merging the code from [release v1.7.0](https://github.com/dorny/test-reporter/tree/v1.7.0) to `main` to keep the commits in order.