### PR TITLE
Fix JUnit message / type fields.

### DIFF
--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -10,4 +10,5 @@ AcmeLibTests.AcmeLibTests
   ✅ test_always_pass
   ✅ test_always_skip
   ❌ test_always_fail
+	failed
 ```

--- a/__tests__/__snapshots__/java-junit.test.ts.snap
+++ b/__tests__/__snapshots__/java-junit.test.ts.snap
@@ -41,7 +41,7 @@ at java.lang.Thread.run(Thread.java:748)
 
     ",
                 "line": 29,
-                "message": undefined,
+                "message": "java.lang.AssertionError: expected [1.2.1] but found [1.2.0]",
                 "path": "pulsar-common/src/test/java/org/apache/pulsar/AddMissingPatchVersionTest.java",
               },
               "name": "testVersionStrings",
@@ -100,7 +100,7 @@ at java.lang.Thread.run(Thread.java:748)
 
     ",
                 "line": 29,
-                "message": undefined,
+                "message": "java.lang.AssertionError: expected [1.2.1] but found [1.2.0]",
                 "path": "pulsar-common/src/test/java/org/apache/pulsar/AddMissingPatchVersionTest.java",
               },
               "name": "testVersionStrings",

--- a/__tests__/__snapshots__/swift-xunit.test.ts.snap
+++ b/__tests__/__snapshots__/swift-xunit.test.ts.snap
@@ -25,7 +25,7 @@ TestRunResult {
               "error": {
                 "details": undefined,
                 "line": undefined,
-                "message": undefined,
+                "message": "failed",
                 "path": undefined,
               },
               "name": "test_always_fail",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1178,7 +1178,7 @@ class JavaJunitParser {
         return 'success';
     }
     getTestCaseError(tc) {
-        var _a;
+        var _a, _b;
         if (!this.options.parseErrors) {
             return undefined;
         }
@@ -1198,11 +1198,18 @@ class JavaJunitParser {
                 line = src.line;
             }
         }
+        let message;
+        if (typeof failure === 'object') {
+            message = failure.$.message;
+            if ((_b = failure.$) === null || _b === void 0 ? void 0 : _b.type) {
+                message = failure.$.type + ': ' + message;
+            }
+        }
         return {
             path: filePath,
             line,
             details,
-            message: typeof failure === 'object' ? failure.message : undefined
+            message
         };
     }
     exceptionThrowSource(stackTrace) {

--- a/src/parsers/java-junit/java-junit-parser.ts
+++ b/src/parsers/java-junit/java-junit-parser.ts
@@ -137,11 +137,20 @@ export class JavaJunitParser implements TestParser {
       }
     }
 
+    
+
+    let message
+    if(typeof failure === 'object') {
+      message = failure.$.message
+      if(failure.$?.type) {
+        message = failure.$.type + ": "+ message
+      }
+    }
     return {
       path: filePath,
       line,
       details,
-      message: typeof failure === 'object' ? failure.message : undefined
+      message
     }
   }
 

--- a/src/parsers/java-junit/java-junit-parser.ts
+++ b/src/parsers/java-junit/java-junit-parser.ts
@@ -137,13 +137,11 @@ export class JavaJunitParser implements TestParser {
       }
     }
 
-    
-
     let message
-    if(typeof failure === 'object') {
+    if (typeof failure === 'object') {
       message = failure.$.message
-      if(failure.$?.type) {
-        message = failure.$.type + ": "+ message
+      if (failure.$?.type) {
+        message = failure.$.type + ': ' + message
       }
     }
     return {

--- a/src/parsers/java-junit/java-junit-types.ts
+++ b/src/parsers/java-junit/java-junit-types.ts
@@ -40,6 +40,8 @@ export interface TestCase {
 
 export interface Failure {
   _: string
-  type: string
-  message: string
+  $: {
+    type?: string
+    message: string
+  }
 }


### PR DESCRIPTION
FYI in the tests it looked like the `message` attribute was working because the first line of the node's `text` happened to match the message attribute.