### PR TITLE
Fix problematic retransmission of authentication token

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2168,7 +2168,7 @@ function downloadArtifact(octokit, artifactId, fileName, token) {
             if (typeof url !== 'string') {
                 throw new Error(`Location header has unexpected value: ${url}`);
             }
-            const downloadStream = got_1.default.stream(url, { headers });
+            const downloadStream = got_1.default.stream(url);
             const fileWriterStream = (0, fs_1.createWriteStream)(fileName);
             core.info(`Downloading ${url}`);
             downloadStream.on('downloadProgress', ({ transferred }) => {

--- a/src/utils/github-utils.ts
+++ b/src/utils/github-utils.ts
@@ -70,7 +70,7 @@ export async function downloadArtifact(
       throw new Error(`Location header has unexpected value: ${url}`)
     }
 
-    const downloadStream = got.stream(url, {headers})
+    const downloadStream = got.stream(url)
     const fileWriterStream = createWriteStream(fileName)
 
     core.info(`Downloading ${url}`)


### PR DESCRIPTION
Should fix #343 and also fix #363. While taking a short look at the implementation, I was wondering if we are actually supposed to retransmit the authentication header. I took a short look at the [API documentation](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact), which reinforced my suspicion by not mentioning any authentication requirements. I therefore just tried to remove the headers from the request, and it worked according to my tests.

Note that the HTTP specification also suggests that you may not want to re-transmit the authentication header. Some google research suggested that you should only re-transmit the header if the target of the redirect is on the same domain.
https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4-6.2.1