### PR TITLE
Fix problematic retransmission of authentication token (alternative solution)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2151,26 +2151,11 @@ function downloadArtifact(octokit, artifactId, fileName, token) {
             const headers = {
                 Authorization: `Bearer ${token}`
             };
-            const resp = yield (0, got_1.default)(req.url, {
-                headers,
-                followRedirect: false
-            });
-            core.info(`Fetch artifact URL: ${resp.statusCode} ${resp.statusMessage}`);
-            if (resp.statusCode !== 302) {
-                throw new Error('Fetch artifact URL failed: received unexpected status code');
-            }
-            const url = resp.headers.location;
-            if (url === undefined) {
-                const receivedHeaders = Object.keys(resp.headers);
-                core.info(`Received headers: ${receivedHeaders.join(', ')}`);
-                throw new Error('Location header was not found in API response');
-            }
-            if (typeof url !== 'string') {
-                throw new Error(`Location header has unexpected value: ${url}`);
-            }
-            const downloadStream = got_1.default.stream(url, { headers });
+            const downloadStream = got_1.default.stream(req.url, { headers });
             const fileWriterStream = (0, fs_1.createWriteStream)(fileName);
-            core.info(`Downloading ${url}`);
+            downloadStream.on('redirect', response => {
+                core.info(`Downloading ${response.headers.location}`);
+            });
             downloadStream.on('downloadProgress', ({ transferred }) => {
                 core.info(`Progress: ${transferred} B`);
             });


### PR DESCRIPTION
Here is an alternative solution to #436. It delegates the redirect-handling to the `got` library, instead of fixing the manual handling. This should fix #343 and fix #363, just as the original solution.