### PR TITLE
Remove log group so logs are flattened

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -343,12 +343,10 @@ class TestReporter {
             const input = yield inputProvider.load();
             for (const [reportName, files] of Object.entries(input)) {
                 try {
-                    core.startGroup(`Creating test report ${reportName}`);
                     const tr = yield this.createReport(parser, reportName, files);
                     results.push(...tr);
                 }
                 finally {
-                    core.endGroup();
                 }
             }
             const isFailed = results.some(tr => tr.result === 'failed');

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,11 +111,9 @@ class TestReporter {
     const input = await inputProvider.load()
     for (const [reportName, files] of Object.entries(input)) {
       try {
-        core.startGroup(`Creating test report ${reportName}`)
         const tr = await this.createReport(parser, reportName, files)
         results.push(...tr)
       } finally {
-        core.endGroup()
       }
     }
 


### PR DESCRIPTION
Removes log group so that the logs with the HTML link shows up right away instead of being hidden under an expand section.