### PR TITLE
Add link on badge when using GH Action Summary

### DIFF
--- a/__tests__/__outputs__/dart-json.md
+++ b/__tests__/__outputs__/dart-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/dart-json.json|1 ✅|4 ❌|1 ⚪|4s|

--- a/__tests__/__outputs__/dart-json.md
+++ b/__tests__/__outputs__/dart-json.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/dart-json.json|1 ✅|4 ❌|1 ⚪|4s|

--- a/__tests__/__outputs__/dotnet-nunit.md
+++ b/__tests__/__outputs__/dotnet-nunit.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/dotnet-nunit.xml|3 ✅|5 ❌|1 ⚪|230ms|

--- a/__tests__/__outputs__/dotnet-nunit.md
+++ b/__tests__/__outputs__/dotnet-nunit.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/dotnet-nunit.xml|3 ✅|5 ❌|1 ⚪|230ms|

--- a/__tests__/__outputs__/dotnet-trx.md
+++ b/__tests__/__outputs__/dotnet-trx.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/dotnet-trx.trx|5 ✅|5 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/dotnet-trx.md
+++ b/__tests__/__outputs__/dotnet-trx.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/dotnet-trx.trx|5 ✅|5 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/fluent-validation-test-results.md
+++ b/__tests__/__outputs__/fluent-validation-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/FluentValidation.Tests.trx|803 ✅||1 ⚪|4s|

--- a/__tests__/__outputs__/fluent-validation-test-results.md
+++ b/__tests__/__outputs__/fluent-validation-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/FluentValidation.Tests.trx|803 ✅||1 ⚪|4s|

--- a/__tests__/__outputs__/jest-junit-eslint.md
+++ b/__tests__/__outputs__/jest-junit-eslint.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/jest-junit-eslint.xml|1 ✅|||0ms|

--- a/__tests__/__outputs__/jest-junit-eslint.md
+++ b/__tests__/__outputs__/jest-junit-eslint.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/jest-junit-eslint.xml|1 ✅|||0ms|

--- a/__tests__/__outputs__/jest-junit.md
+++ b/__tests__/__outputs__/jest-junit.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/jest-junit.xml|1 ✅|4 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/jest-junit.md
+++ b/__tests__/__outputs__/jest-junit.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/jest-junit.xml|1 ✅|4 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/jest-react-component-test-results.md
+++ b/__tests__/__outputs__/jest-react-component-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/jest/jest-react-component-test-results.xml|1 ✅|||1000ms|

--- a/__tests__/__outputs__/jest-react-component-test-results.md
+++ b/__tests__/__outputs__/jest-react-component-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/jest/jest-react-component-test-results.xml|1 ✅|||1000ms|

--- a/__tests__/__outputs__/jest-test-results.md
+++ b/__tests__/__outputs__/jest-test-results.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/jest/jest-test-results.xml|4207 ✅|2 ❌|30 ⚪|166s|

--- a/__tests__/__outputs__/jest-test-results.md
+++ b/__tests__/__outputs__/jest-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/jest/jest-test-results.xml|4207 ✅|2 ❌|30 ⚪|166s|

--- a/__tests__/__outputs__/mocha-json.md
+++ b/__tests__/__outputs__/mocha-json.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/mocha-json.json|1 ✅|4 ❌|1 ⚪|12ms|

--- a/__tests__/__outputs__/mocha-json.md
+++ b/__tests__/__outputs__/mocha-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/mocha-json.json|1 ✅|4 ❌|1 ⚪|12ms|

--- a/__tests__/__outputs__/mocha-test-results.md
+++ b/__tests__/__outputs__/mocha-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/mocha/mocha-test-results.json|833 ✅||6 ⚪|6s|

--- a/__tests__/__outputs__/mocha-test-results.md
+++ b/__tests__/__outputs__/mocha-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/mocha/mocha-test-results.json|833 ✅||6 ⚪|6s|

--- a/__tests__/__outputs__/provider-test-results.md
+++ b/__tests__/__outputs__/provider-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/flutter/provider-test-results.json|268 ✅|1 ❌||0ms|

--- a/__tests__/__outputs__/provider-test-results.md
+++ b/__tests__/__outputs__/provider-test-results.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/flutter/provider-test-results.json|268 ✅|1 ❌||0ms|

--- a/__tests__/__outputs__/pulsar-test-results-no-merge.md
+++ b/__tests__/__outputs__/pulsar-test-results-no-merge.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml||1 ❌|1 ⚪|116ms|

--- a/__tests__/__outputs__/pulsar-test-results-no-merge.md
+++ b/__tests__/__outputs__/pulsar-test-results-no-merge.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml||1 ❌|1 ⚪|116ms|

--- a/__tests__/__outputs__/pulsar-test-results.md
+++ b/__tests__/__outputs__/pulsar-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/java/pulsar-test-report.xml|793 ✅|1 ❌|14 ⚪|2127s|

--- a/__tests__/__outputs__/pulsar-test-results.md
+++ b/__tests__/__outputs__/pulsar-test-results.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/java/pulsar-test-report.xml|793 ✅|1 ❌|14 ⚪|2127s|

--- a/__tests__/__outputs__/rspec-json.md
+++ b/__tests__/__outputs__/rspec-json.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/rspec-json.json|1 ✅|1 ❌|1 ⚪|0ms|

--- a/__tests__/__outputs__/rspec-json.md
+++ b/__tests__/__outputs__/rspec-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/rspec-json.json|1 ✅|1 ❌|1 ⚪|0ms|

--- a/__tests__/__outputs__/silent-notes-test-results.md
+++ b/__tests__/__outputs__/silent-notes-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/SilentNotes.trx|67 ✅||12 ⚪|1s|

--- a/__tests__/__outputs__/silent-notes-test-results.md
+++ b/__tests__/__outputs__/silent-notes-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/external/SilentNotes.trx|67 ✅||12 ⚪|1s|

--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/swift-xunit.xml|2 ✅|1 ❌||220ms|

--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |fixtures/swift-xunit.xml|2 ✅|1 ❌||220ms|

--- a/dist/index.js
+++ b/dist/index.js
@@ -1845,7 +1845,7 @@ function getBadge(passed, failed, skipped, options) {
     }
     const hint = failed > 0 ? 'Tests failed' : 'Tests passed successfully';
     const uri = encodeURIComponent(`${options.badgeTitle}-${message}-${color}`);
-    return `[![${hint}](https://img.shields.io/badge/${uri})](#test-report)`;
+    return `[![${hint}](https://img.shields.io/badge/${uri})](#user-content-test-report)`;
 }
 function getTestRunsReport(testRuns, options) {
     const sections = [];
@@ -1854,7 +1854,7 @@ function getTestRunsReport(testRuns, options) {
         sections.push(`<details><summary>Expand for details</summary>`);
         sections.push(` `);
     }
-    sections.push('# <a name="test-report"></a> Tests report');
+    sections.push('# <a name="user-content-test-report"></a> Tests report');
     if (testRuns.length > 0 || options.onlySummary) {
         const tableData = testRuns
             .filter(tr => tr.passed > 0 || tr.failed > 0 || tr.skipped > 0)

--- a/dist/index.js
+++ b/dist/index.js
@@ -1845,7 +1845,7 @@ function getBadge(passed, failed, skipped, options) {
     }
     const hint = failed > 0 ? 'Tests failed' : 'Tests passed successfully';
     const uri = encodeURIComponent(`${options.badgeTitle}-${message}-${color}`);
-    return `![${hint}](https://img.shields.io/badge/${uri})`;
+    return `[![${hint}](https://img.shields.io/badge/${uri})](#test-report)`;
 }
 function getTestRunsReport(testRuns, options) {
     const sections = [];
@@ -1854,6 +1854,7 @@ function getTestRunsReport(testRuns, options) {
         sections.push(`<details><summary>Expand for details</summary>`);
         sections.push(` `);
     }
+    sections.push('# <a name="test-report"></a> Tests report');
     if (testRuns.length > 0 || options.onlySummary) {
         const tableData = testRuns
             .filter(tr => tr.passed > 0 || tr.failed > 0 || tr.skipped > 0)

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -138,7 +138,7 @@ function getBadge(passed: number, failed: number, skipped: number, options: Repo
   }
   const hint = failed > 0 ? 'Tests failed' : 'Tests passed successfully'
   const uri = encodeURIComponent(`${options.badgeTitle}-${message}-${color}`)
-  return `![${hint}](https://img.shields.io/badge/${uri})`
+  return `[![${hint}](https://img.shields.io/badge/${uri})](#test-report)`
 }
 
 function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): string[] {
@@ -148,6 +148,8 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
     sections.push(`<details><summary>Expand for details</summary>`)
     sections.push(` `)
   }
+
+  sections.push('# <a name="test-report"></a> Tests report')
 
   if (testRuns.length > 0 || options.onlySummary) {
     const tableData = testRuns

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -138,7 +138,7 @@ function getBadge(passed: number, failed: number, skipped: number, options: Repo
   }
   const hint = failed > 0 ? 'Tests failed' : 'Tests passed successfully'
   const uri = encodeURIComponent(`${options.badgeTitle}-${message}-${color}`)
-  return `[![${hint}](https://img.shields.io/badge/${uri})](#test-report)`
+  return `[![${hint}](https://img.shields.io/badge/${uri})](#user-content-test-report)`
 }
 
 function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): string[] {
@@ -149,7 +149,7 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
     sections.push(` `)
   }
 
-  sections.push('# <a name="test-report"></a> Tests report')
+  sections.push('# <a name="user-content-test-report"></a> Tests report')
 
   if (testRuns.length > 0 || options.onlySummary) {
     const tableData = testRuns


### PR DESCRIPTION
## Problem
As of now, clicking on the badge on GH Action Summary:
<img width="208" alt="image" src="https://github.com/dorny/test-reporter/assets/1562400/687da6c0-ad6f-4c05-b546-efcb0d845fd1">

goes to nowhere interesting (`https://camo.githubusercontent.com/xxx`).

## This PR
This (completely unsolicited) PR introduces a new feature: the badge is now in an anchor, and when clicked, this open the collapsed section and goes to the top of the tests report. At least, I can click roughly on a bigger thing than a small collapsed section 🤷‍♂️

<img width="767" alt="image" src="https://github.com/dorny/test-reporter/assets/1562400/36ee0944-f2c9-4c34-b42e-42870bda3ac1">
 
## Next
Nothing fancy, I just like it this way 🤷‍♂️ Hope you like it too! Thanks for this gh action btw.