### PR TITLE
Add StdOut to UnitTestResult object

### DIFF
--- a/src/parsers/dotnet-trx/dotnet-trx-types.ts
+++ b/src/parsers/dotnet-trx/dotnet-trx-types.ts
@@ -51,6 +51,7 @@ export interface UnitTestResult {
 
 export interface Output {
   ErrorInfo: ErrorInfo[]
+  StdOut: string
 }
 export interface ErrorInfo {
   Message: string[]


### PR DESCRIPTION
In order to include the console output I'd like to add the stdout scope to the test results object.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/8679e72a-1db5-4938-96a9-520a108f8556" />
