### PR TITLE
Increase step summary limit to 1MiB

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1792,7 +1792,7 @@ const node_utils_1 = __nccwpck_require__(5384);
 const parse_utils_1 = __nccwpck_require__(9633);
 const slugger_1 = __nccwpck_require__(9537);
 const MAX_REPORT_LENGTH = 65535;
-const MAX_ACTIONS_SUMMARY_LENGTH = 131072; // 1048576 soon
+const MAX_ACTIONS_SUMMARY_LENGTH = 1048576;
 const defaultOptions = {
     listSuites: 'all',
     listTests: 'all',

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -6,7 +6,7 @@ import {getFirstNonEmptyLine} from '../utils/parse-utils'
 import {slug} from '../utils/slugger'
 
 const MAX_REPORT_LENGTH = 65535
-const MAX_ACTIONS_SUMMARY_LENGTH = 131072 // 1048576 soon
+const MAX_ACTIONS_SUMMARY_LENGTH = 1048576
 
 export interface ReportOptions {
   listSuites: 'all' | 'failed' | 'none'


### PR DESCRIPTION
This PR aligns the limit of the allowed 'step-summary' report size for the action with the GitHub limit for the GITHUB_STEP_SUMMARY (https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#step-isolation-and-limits)
Test run: https://github.com/OlesGalatsan/test-trx/actions/runs/15045312655#summary-42286264533