### PR TITLE
Fix for empty TRX TestDefinitions

### DIFF
--- a/__tests__/dotnet-trx.test.ts
+++ b/__tests__/dotnet-trx.test.ts
@@ -23,6 +23,22 @@ describe('dotnet-trx tests', () => {
     expect(result.result).toBe('success')
   })
 
+  it('produces empty test run result when TestDefinitions is empty', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'empty', 'dotnet-trx-empty-test-definitions.trx')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new DotnetTrxParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result.tests).toBe(0)
+    expect(result.result).toBe('success')
+  })
+
   it('matches report snapshot', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'dotnet-trx.trx')
     const outputPath = path.join(__dirname, '__outputs__', 'dotnet-trx.md')

--- a/__tests__/fixtures/empty/dotnet-trx-empty-test-definitions.trx
+++ b/__tests__/fixtures/empty/dotnet-trx-empty-test-definitions.trx
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="80e4c095-f726-4ab2-9441-416daa162672" name="..." runUser="..." xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2021-02-26T10:36:33.7131022+02:00" queuing="2021-02-26T10:36:33.7131029+02:00" start="2021-02-26T10:36:33.3278956+02:00" finish="2021-02-26T10:36:33.7139830+02:00" />
+  <TestSettings name="default" id="863a1d8b-ee3b-45f9-86ee-1869bc4e889f">
+    <Deployment runDeploymentRoot="..." />
+  </TestSettings>
+  <Results />
+  <TestDefinitions />
+  <TestEntries />
+  <TestLists>
+    <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <ResultSummary outcome="Completed">
+    <Counters total="0" executed="0" passed="0" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <RunInfos>
+      <RunInfo computerName="..." outcome="Warning" timestamp="2021-02-26T10:36:33.6676104+02:00">
+        <Text>No test is available in (...). Make sure that test discoverer &amp; executors are registered and platform &amp; framework version settings are appropriate and try again.</Text>
+      </RunInfo>
+    </RunInfos>
+  </ResultSummary>
+</TestRun>

--- a/dist/index.js
+++ b/dist/index.js
@@ -937,7 +937,8 @@ class DotnetTrxParser {
         }
     }
     getTestClasses(trx) {
-        if (trx.TestRun.TestDefinitions === undefined || trx.TestRun.Results === undefined) {
+        if (trx.TestRun.TestDefinitions === undefined || trx.TestRun.Results === undefined ||
+            !trx.TestRun.TestDefinitions.some(td => td.UnitTest && Array.isArray(td.UnitTest))) {
             return [];
         }
         const unitTests = {};

--- a/src/parsers/dotnet-trx/dotnet-trx-parser.ts
+++ b/src/parsers/dotnet-trx/dotnet-trx-parser.ts
@@ -62,7 +62,8 @@ export class DotnetTrxParser implements TestParser {
   }
 
   private getTestClasses(trx: TrxReport): TestClass[] {
-    if (trx.TestRun.TestDefinitions === undefined || trx.TestRun.Results === undefined) {
+    if (trx.TestRun.TestDefinitions === undefined || trx.TestRun.Results === undefined ||
+        !trx.TestRun.TestDefinitions.some(td => td.UnitTest && Array.isArray(td.UnitTest))) {
       return []
     }
 


### PR DESCRIPTION
This PR is a fix for https://github.com/phoenix-actions/test-reporting/issues/64 that is also relevant for this action.
Currently, this action only checks if TestDefinitions are not defined, but it is possible that it will just be empty:
```
<?xml version="1.0" encoding="utf-8"?>
<TestRun id="f4386078-5371-420d-b9c6-122f1e77f109" name="test" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
  <Times creation="2025-05-13T12:53:18.295323Z" queuing="2025-05-13T12:53:18.295323Z" start="2025-05-13T12:53:18.295323Z" finish="2025-05-13T12:53:18.4362393Z" />
  <TestSettings name="default" id="f25a2621-1af4-4d50-a859-619a3039691e">
    <Deployment runDeploymentRoot="test" />
  </TestSettings>
  <Results />
  <TestDefinitions />
  <TestEntries />
  <TestLists>
    <TestList name="Results Not in a List" id="8C84FA94-04C1-424b-9868-57A2D4851A1D" />
    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
  </TestLists>
  <ResultSummary outcome="Completed">
    <Counters total="0" executed="0" passed="0" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
  </ResultSummary>
</TestRun>
```
In order to fix it, we need to check if td.UnitTest exists and is an array for it to be then parsed.
Test run: https://github.com/OlesGalatsan/MstTrx/actions/runs/15045476377