### PR TITLE
Add type definitions to `github-utils.ts`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2435,11 +2435,11 @@ async function downloadArtifact(octokit, artifactId, fileName, token) {
         };
         const downloadStream = got_1.default.stream(req.url, { headers });
         const fileWriterStream = (0, fs_1.createWriteStream)(fileName);
-        downloadStream.on('redirect', response => {
+        downloadStream.on('redirect', (response) => {
             core.info(`Downloading ${response.headers.location}`);
         });
-        downloadStream.on('downloadProgress', ({ transferred }) => {
-            core.info(`Progress: ${transferred} B`);
+        downloadStream.on('downloadProgress', (progress) => {
+            core.info(`Progress: ${progress.transferred} B`);
         });
         await asyncStream(downloadStream, fileWriterStream);
     }

--- a/src/utils/github-utils.ts
+++ b/src/utils/github-utils.ts
@@ -2,7 +2,7 @@ import {createWriteStream} from 'fs'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {GitHub} from '@actions/github/lib/utils'
-import type {PullRequest} from '@octokit/webhooks-types'
+import type {PullRequest, WorkflowRunEvent} from '@octokit/webhooks-types'
 import * as stream from 'stream'
 import {promisify} from 'util'
 import got from 'got'
@@ -11,7 +11,7 @@ const asyncStream = promisify(stream.pipeline)
 export function getCheckRunContext(): {sha: string; runId: number} {
   if (github.context.eventName === 'workflow_run') {
     core.info('Action was triggered by workflow_run: using SHA and RUN_ID from triggering workflow')
-    const event = github.context.payload
+    const event = github.context.payload as WorkflowRunEvent
     if (!event.workflow_run) {
       throw new Error("Event of type 'workflow_run' is missing 'workflow_run' field")
     }

--- a/src/utils/github-utils.ts
+++ b/src/utils/github-utils.ts
@@ -3,9 +3,10 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {GitHub} from '@actions/github/lib/utils'
 import type {PullRequest, WorkflowRunEvent} from '@octokit/webhooks-types'
+import {IncomingMessage} from 'http'
 import * as stream from 'stream'
 import {promisify} from 'util'
-import got from 'got'
+import got, {Progress} from 'got'
 const asyncStream = promisify(stream.pipeline)
 
 export function getCheckRunContext(): {sha: string; runId: number} {
@@ -54,11 +55,11 @@ export async function downloadArtifact(
     const downloadStream = got.stream(req.url, {headers})
     const fileWriterStream = createWriteStream(fileName)
 
-    downloadStream.on('redirect', response => {
+    downloadStream.on('redirect', (response: IncomingMessage) => {
       core.info(`Downloading ${response.headers.location}`)
     })
-    downloadStream.on('downloadProgress', ({transferred}) => {
-      core.info(`Progress: ${transferred} B`)
+    downloadStream.on('downloadProgress', (progress: Progress) => {
+      core.info(`Progress: ${progress.transferred} B`)
     })
 
     await asyncStream(downloadStream, fileWriterStream)


### PR DESCRIPTION
* Use typed `WorkflowRunEvent` when parsing `workflow_run` payload
* Use types arguments in the `downloadStream` event handlers

Code improvements for issue #603