### PR TITLE
Add stack trace from trx to summary

### DIFF
--- a/__tests__/__outputs__/dotnet-trx-only-failed.md
+++ b/__tests__/__outputs__/dotnet-trx-only-failed.md
@@ -11,18 +11,24 @@
 ```
 ❌ Exception_In_TargetTest
 	System.DivideByZeroException : Attempted to divide by zero.
+	   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.Unit\Calculator.cs:line 9
+	   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 33
 ❌ Exception_In_Test
 	System.Exception : Test
+	   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 39
 ❌ Failing_Test
 	Assert.Equal() Failure
 	Expected: 3
 	Actual:   2
+	   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 27
 ❌ Is_Even_Number(i: 3)
 	Assert.True() Failure
 	Expected: True
 	Actual:   False
+	   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 59
 ❌ Should be even number(i: 3)
 	Assert.True() Failure
 	Expected: True
 	Actual:   False
+	   at DotnetTests.XUnitTests.CalculatorTests.Theory_With_Custom_Name(Int32 i) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 67
 ```

--- a/__tests__/__outputs__/dotnet-trx.md
+++ b/__tests__/__outputs__/dotnet-trx.md
@@ -12,23 +12,29 @@
 ✅ Custom Name
 ❌ Exception_In_TargetTest
 	System.DivideByZeroException : Attempted to divide by zero.
+	   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.Unit\Calculator.cs:line 9
+	   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 33
 ❌ Exception_In_Test
 	System.Exception : Test
+	   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 39
 ❌ Failing_Test
 	Assert.Equal() Failure
 	Expected: 3
 	Actual:   2
+	   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 27
 ✅ Is_Even_Number(i: 2)
 ❌ Is_Even_Number(i: 3)
 	Assert.True() Failure
 	Expected: True
 	Actual:   False
+	   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 59
 ✅ Passing_Test
 ✅ Should be even number(i: 2)
 ❌ Should be even number(i: 3)
 	Assert.True() Failure
 	Expected: True
 	Actual:   False
+	   at DotnetTests.XUnitTests.CalculatorTests.Theory_With_Custom_Name(Int32 i) in C:\Users\Michal\Workspace\dorny\test-reporter\reports\dotnet\DotnetTests.XUnitTests\CalculatorTests.cs:line 67
 ⚪ Skipped_Test
 ✅ Timeout_Test
 ```

--- a/__tests__/__snapshots__/dotnet-trx.test.ts.snap
+++ b/__tests__/__snapshots__/dotnet-trx.test.ts.snap
@@ -21,7 +21,9 @@ TestRunResult {
    at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.Unit\\Calculator.cs:line 9
    at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 33",
                 "line": 9,
-                "message": "System.DivideByZeroException : Attempted to divide by zero.",
+                "message": "System.DivideByZeroException : Attempted to divide by zero.
+   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.Unit\\Calculator.cs:line 9
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 33",
                 "path": "DotnetTests.Unit/Calculator.cs",
               },
               "name": "Exception_In_TargetTest",
@@ -33,7 +35,8 @@ TestRunResult {
                 "details": "System.Exception : Test
    at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 39",
                 "line": 39,
-                "message": "System.Exception : Test",
+                "message": "System.Exception : Test
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 39",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Exception_In_Test",
@@ -49,7 +52,8 @@ Actual:   2
                 "line": 27,
                 "message": "Assert.Equal() Failure
 Expected: 3
-Actual:   2",
+Actual:   2
+   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 27",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Failing_Test",
@@ -71,7 +75,8 @@ Actual:   False
                 "line": 59,
                 "message": "Assert.True() Failure
 Expected: True
-Actual:   False",
+Actual:   False
+   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 59",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Is_Even_Number(i: 3)",
@@ -99,7 +104,8 @@ Actual:   False
                 "line": 67,
                 "message": "Assert.True() Failure
 Expected: True
-Actual:   False",
+Actual:   False
+   at DotnetTests.XUnitTests.CalculatorTests.Theory_With_Custom_Name(Int32 i) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 67",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Should be even number(i: 3)",
@@ -150,7 +156,9 @@ TestRunResult {
    at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.Unit\\Calculator.cs:line 9
    at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 33",
                 "line": 9,
-                "message": "System.DivideByZeroException : Attempted to divide by zero.",
+                "message": "System.DivideByZeroException : Attempted to divide by zero.
+   at DotnetTests.Unit.Calculator.Div(Int32 a, Int32 b) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.Unit\\Calculator.cs:line 9
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_TargetTest() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 33",
                 "path": "DotnetTests.Unit/Calculator.cs",
               },
               "name": "Exception_In_TargetTest",
@@ -162,7 +170,8 @@ TestRunResult {
                 "details": "System.Exception : Test
    at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 39",
                 "line": 39,
-                "message": "System.Exception : Test",
+                "message": "System.Exception : Test
+   at DotnetTests.XUnitTests.CalculatorTests.Exception_In_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 39",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Exception_In_Test",
@@ -178,7 +187,8 @@ Actual:   2
                 "line": 27,
                 "message": "Assert.Equal() Failure
 Expected: 3
-Actual:   2",
+Actual:   2
+   at DotnetTests.XUnitTests.CalculatorTests.Failing_Test() in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 27",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Failing_Test",
@@ -200,7 +210,8 @@ Actual:   False
                 "line": 59,
                 "message": "Assert.True() Failure
 Expected: True
-Actual:   False",
+Actual:   False
+   at DotnetTests.XUnitTests.CalculatorTests.Is_Even_Number(Int32 i) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 59",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Is_Even_Number(i: 3)",
@@ -228,7 +239,8 @@ Actual:   False
                 "line": 67,
                 "message": "Assert.True() Failure
 Expected: True
-Actual:   False",
+Actual:   False
+   at DotnetTests.XUnitTests.CalculatorTests.Theory_With_Custom_Name(Int32 i) in C:\\Users\\Michal\\Workspace\\dorny\\test-reporter\\reports\\dotnet\\DotnetTests.XUnitTests\\CalculatorTests.cs:line 67",
                 "path": "DotnetTests.XUnitTests/CalculatorTests.cs",
               },
               "name": "Should be even number(i: 3)",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1025,8 +1025,8 @@ class DotnetTrxParser {
             error.StackTrace.length === 0) {
             return undefined;
         }
-        const message = test.error.Message[0];
         const stackTrace = test.error.StackTrace[0];
+        const message = `${test.error.Message[0]}\n${stackTrace}`;
         let path;
         let line;
         const src = this.exceptionThrowSource(stackTrace);
@@ -1038,7 +1038,7 @@ class DotnetTrxParser {
             path,
             line,
             message,
-            details: `${message}\n${stackTrace}`
+            details: `${message}`
         };
     }
     exceptionThrowSource(stackTrace) {

--- a/src/parsers/dotnet-trx/dotnet-trx-parser.ts
+++ b/src/parsers/dotnet-trx/dotnet-trx-parser.ts
@@ -146,8 +146,8 @@ export class DotnetTrxParser implements TestParser {
       return undefined
     }
 
-    const message = test.error.Message[0]
     const stackTrace = test.error.StackTrace[0]
+    const message = `${test.error.Message[0]}\n${stackTrace}`
     let path
     let line
 
@@ -161,7 +161,7 @@ export class DotnetTrxParser implements TestParser {
       path,
       line,
       message,
-      details: `${message}\n${stackTrace}`
+      details: `${message}`
     }
   }
 


### PR DESCRIPTION
This update allows displaying a stack trace for failed tests in trx file directly in GitHub summary as it's already available for some other report types.