### PR TITLE
Fix `no-shadow`: Disallow variable declarations from shadowing variables declared in the outer scope

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -837,12 +837,12 @@ class DotnetNunitParser {
             .map(suite => suite.$.name)
             .join('.');
         const groupName = suitesWithoutTheories[suitesWithoutTheories.length - 1].$.name;
-        let existingSuite = result.find(existingSuite => existingSuite.name === suiteName);
+        let existingSuite = result.find(suite => suite.name === suiteName);
         if (existingSuite === undefined) {
             existingSuite = new test_results_1.TestSuiteResult(suiteName, []);
             result.push(existingSuite);
         }
-        let existingGroup = existingSuite.groups.find(existingGroup => existingGroup.name === groupName);
+        let existingGroup = existingSuite.groups.find(group => group.name === groupName);
         if (existingGroup === undefined) {
             existingGroup = new test_results_1.TestGroupResult(groupName, []);
             existingSuite.groups.push(existingGroup);

--- a/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
+++ b/src/parsers/dotnet-nunit/dotnet-nunit-parser.ts
@@ -77,13 +77,13 @@ export class DotnetNunitParser implements TestParser {
       .join('.')
     const groupName = suitesWithoutTheories[suitesWithoutTheories.length - 1].$.name
 
-    let existingSuite = result.find(existingSuite => existingSuite.name === suiteName)
+    let existingSuite = result.find(suite => suite.name === suiteName)
     if (existingSuite === undefined) {
       existingSuite = new TestSuiteResult(suiteName, [])
       result.push(existingSuite)
     }
 
-    let existingGroup = existingSuite.groups.find(existingGroup => existingGroup.name === groupName)
+    let existingGroup = existingSuite.groups.find(group => group.name === groupName)
     if (existingGroup === undefined) {
       existingGroup = new TestGroupResult(groupName, [])
       existingSuite.groups.push(existingGroup)


### PR DESCRIPTION
Fixes error `no-shadow`: Disallow variable declarations from shadowing variables declared in the outer scope.