### PR TITLE
Define the `report-title` attribute in action definition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,10 @@ inputs:
   working-directory:
     description: Relative path under $GITHUB_WORKSPACE where the repository was checked out
     required: false
+  report-title:
+    description: Title for the test report summary
+    required: false
+    default: ''
   only-summary:
     description: |
       Allows you to generate only the summary.


### PR DESCRIPTION
Fixes missing attribute from PR #568

Implement the simpler part of the #610:
> The first issue was that the new report-title option is missing from the GitHub Action's input. The mentioned PR added the back end logic, tests and even updated the documentation, but missed adding it to the action.