### PR TITLE
Fix short summary formatting when a report title is present

### DIFF
--- a/__tests__/jest-junit.test.ts
+++ b/__tests__/jest-junit.test.ts
@@ -207,4 +207,47 @@ describe('jest-junit tests', () => {
     // Report should have the title as the first line
     expect(report).toMatch(/^# My Custom Title\n/)
   })
+
+  it('report includes the short summary', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'jest-junit.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new JestJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    const shortSummary = '1 passed, 4 failed and 1 skipped'
+    const report = getReport([result], DEFAULT_OPTIONS, shortSummary)
+    // Report should have the title as the first line
+    expect(report).toMatch(/^## 1 passed, 4 failed and 1 skipped\n/)
+  })
+
+  it('report includes a custom report title and short summary', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'jest-junit.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new JestJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    const shortSummary = '1 passed, 4 failed and 1 skipped'
+    const report = getReport(
+      [result],
+      {
+        ...DEFAULT_OPTIONS,
+        reportTitle: 'My Custom Title'
+      },
+      shortSummary
+    )
+    // Report should have the title as the first line
+    expect(report).toMatch(/^# My Custom Title\n## 1 passed, 4 failed and 1 skipped\n/)
+  })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -408,6 +408,7 @@ class TestReporter {
         const shortSummary = `${passed} passed, ${failed} failed and ${skipped} skipped `;
         let baseUrl = '';
         if (this.useActionsSummary) {
+            core.info(`Creating action summary`);
             const summary = (0, get_report_1.getReport)(results, {
                 listSuites,
                 listTests,
@@ -416,10 +417,9 @@ class TestReporter {
                 useActionsSummary,
                 badgeTitle,
                 reportTitle
-            });
+            }, shortSummary);
             core.info('Summary content:');
             core.info(summary);
-            core.summary.addRaw(`# ${shortSummary}`);
             await core.summary.addRaw(summary).write();
         }
         else {
@@ -1925,11 +1925,10 @@ exports.DEFAULT_OPTIONS = {
     badgeTitle: 'tests',
     reportTitle: ''
 };
-function getReport(results, options = exports.DEFAULT_OPTIONS) {
-    core.info('Generating check run summary');
+function getReport(results, options = exports.DEFAULT_OPTIONS, shortSummary = '') {
     applySort(results);
     const opts = { ...options };
-    let lines = renderReport(results, opts);
+    let lines = renderReport(results, opts, shortSummary);
     let report = lines.join('\n');
     if (getByteLength(report) <= getMaxReportLength(options)) {
         return report;
@@ -1937,7 +1936,7 @@ function getReport(results, options = exports.DEFAULT_OPTIONS) {
     if (opts.listTests === 'all') {
         core.info("Test report summary is too big - setting 'listTests' to 'failed'");
         opts.listTests = 'failed';
-        lines = renderReport(results, opts);
+        lines = renderReport(results, opts, shortSummary);
         report = lines.join('\n');
         if (getByteLength(report) <= getMaxReportLength(options)) {
             return report;
@@ -1984,11 +1983,14 @@ function applySort(results) {
 function getByteLength(text) {
     return Buffer.byteLength(text, 'utf8');
 }
-function renderReport(results, options) {
+function renderReport(results, options, shortSummary) {
     const sections = [];
     const reportTitle = options.reportTitle.trim();
     if (reportTitle) {
         sections.push(`# ${reportTitle}`);
+    }
+    if (shortSummary) {
+        sections.push(`## ${shortSummary}`);
     }
     const badge = getReportBadge(results, options);
     sections.push(badge);

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,19 +175,23 @@ class TestReporter {
 
     let baseUrl = ''
     if (this.useActionsSummary) {
-      const summary = getReport(results, {
-        listSuites,
-        listTests,
-        baseUrl,
-        onlySummary,
-        useActionsSummary,
-        badgeTitle,
-        reportTitle
-      })
+      core.info(`Creating action summary`)
+      const summary = getReport(
+        results,
+        {
+          listSuites,
+          listTests,
+          baseUrl,
+          onlySummary,
+          useActionsSummary,
+          badgeTitle,
+          reportTitle
+        },
+        shortSummary
+      )
 
       core.info('Summary content:')
       core.info(summary)
-      core.summary.addRaw(`# ${shortSummary}`)
       await core.summary.addRaw(summary).write()
     } else {
       core.info(`Creating check run ${name}`)

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -28,13 +28,15 @@ export const DEFAULT_OPTIONS: ReportOptions = {
   reportTitle: ''
 }
 
-export function getReport(results: TestRunResult[], options: ReportOptions = DEFAULT_OPTIONS): string {
-  core.info('Generating check run summary')
-
+export function getReport(
+  results: TestRunResult[],
+  options: ReportOptions = DEFAULT_OPTIONS,
+  shortSummary = ''
+): string {
   applySort(results)
 
   const opts = {...options}
-  let lines = renderReport(results, opts)
+  let lines = renderReport(results, opts, shortSummary)
   let report = lines.join('\n')
 
   if (getByteLength(report) <= getMaxReportLength(options)) {
@@ -44,7 +46,7 @@ export function getReport(results: TestRunResult[], options: ReportOptions = DEF
   if (opts.listTests === 'all') {
     core.info("Test report summary is too big - setting 'listTests' to 'failed'")
     opts.listTests = 'failed'
-    lines = renderReport(results, opts)
+    lines = renderReport(results, opts, shortSummary)
     report = lines.join('\n')
     if (getByteLength(report) <= getMaxReportLength(options)) {
       return report
@@ -101,12 +103,16 @@ function getByteLength(text: string): number {
   return Buffer.byteLength(text, 'utf8')
 }
 
-function renderReport(results: TestRunResult[], options: ReportOptions): string[] {
+function renderReport(results: TestRunResult[], options: ReportOptions, shortSummary: string): string[] {
   const sections: string[] = []
 
   const reportTitle: string = options.reportTitle.trim()
   if (reportTitle) {
     sections.push(`# ${reportTitle}`)
+  }
+
+  if (shortSummary) {
+    sections.push(`## ${shortSummary}`)
   }
 
   const badge = getReportBadge(results, options)


### PR DESCRIPTION
This PR pushes the short summary into `getReport` so that it can appear underneath the optional report title when the report is rendered as an action summary. With this change, the short summary is rendered as H2 to account for the title being H1.

Resolves #644 

Result with title and short summary:
<img width="1357" height="330" alt="Screenshot 2025-07-28 at 1 04 00 PM" src="https://github.com/user-attachments/assets/fb62f7f5-746d-4fde-9e30-530800f57d19" />

Result with short summary only:
<img width="1357" height="253" alt="Screenshot 2025-07-28 at 2 32 33 PM" src="https://github.com/user-attachments/assets/cac74898-7bf6-4484-b8ba-57c057d4b37f" />
