### PR TITLE
early return for empty suites in get-report.ts

### DIFF
--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -195,6 +195,12 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
   const sections: string[] = []
   const suites = options.listSuites === 'failed' ? tr.failedSuites : tr.suites
 
+  // suites gets filtered by options.listSuites, if the suites are empty, it should exit.
+  // currently it still displays all the non-failed items, making the report very verbose.
+  if (suites.length === 0) {
+    return sections
+  }  
+
   if (options.listSuites !== 'none') {
     const trSlug = makeRunSlug(runIndex, options)
     const nameLink = `<a id="${trSlug.id}" href="${options.baseUrl + trSlug.link}">${tr.path}</a>`


### PR DESCRIPTION
When running a lot of unit tests, when few fails, the only way for someone to see the error message is if the `only-summary=false`.

But when the only-summary is false, it displays the table and the suite report below it, and repeating the same information as the ones that passed.

list-suites=failed, seems to be the appropriate fields to only show the failing tests with error message, but that does not work.

Checking the code, it looks like it is not used in the get-reporter.ts. 

I debugged it, and ideally once he suites gets filtered out, it should early return.

Please review/approve.