### PR TITLE
Fix overflow in Actions Summary

### DIFF
--- a/__tests__/report/get-report.test.ts
+++ b/__tests__/report/get-report.test.ts
@@ -22,7 +22,7 @@ describe('trimReport', () => {
     const trimmed = trimReport(MAX_LEN_REPORT, 0, DEFAULT_OPTIONS)
     const trimmedLength = getByteLength(trimmed)
 
-    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expect(trimmed.endsWith('has been trimmed**')).toBe(true) // assert was trimmed
     expectToBeWithinRangeOfCeiling(trimmedLength, MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE, TEST_LINE_LEN)
   })
 
@@ -31,7 +31,7 @@ describe('trimReport', () => {
     const trimmed = trimReport(MAX_LEN_REPORT, prependStringLen, DEFAULT_OPTIONS)
     const trimmedLength = getByteLength(trimmed)
 
-    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expect(trimmed.endsWith('has been trimmed**')).toBe(true) // assert was trimmed
     expectToBeWithinRangeOfCeiling(
       trimmedLength,
       MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE - prependStringLen,
@@ -55,7 +55,7 @@ describe('getReport', () => {
     const trimmed = getReport(MAX_LEN_RESULT, DEFAULT_OPTIONS)
     const trimmedLength = getByteLength(trimmed)
 
-    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expect(trimmed.endsWith('has been trimmed**')).toBe(true) // assert was trimmed
     expectToBeWithinRangeOfCeiling(trimmedLength, MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE, FAILURE_ROW_LEN)
   })
 
@@ -65,7 +65,7 @@ describe('getReport', () => {
     const trimmed = getReport(MAX_LEN_RESULT, DEFAULT_OPTIONS, prependString)
     const trimmedLength = getByteLength(trimmed)
 
-    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expect(trimmed.endsWith('has been trimmed**')).toBe(true) // assert was trimmed
     expectToBeWithinRangeOfCeiling(
       trimmedLength,
       MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE - prependStringLen,

--- a/__tests__/report/get-report.test.ts
+++ b/__tests__/report/get-report.test.ts
@@ -1,0 +1,83 @@
+import {
+  DEFAULT_OPTIONS,
+  getByteLength,
+  getReport,
+  MAX_ACTIONS_SUMMARY_LENGTH,
+  trimReport
+} from '../../src/report/get-report'
+import {TestCaseResult, TestGroupResult, TestRunResult, TestSuiteResult} from '../../src/test-results'
+
+// space reserved for closing backticks and newlines
+const ALWAYS_RESERVED_SPACE = 5
+
+describe('trimReport', () => {
+  const TEST_LINE_CHAR = '----'
+  const TEST_LINE_LEN = getByteLength(`${TEST_LINE_CHAR}\n`)
+  const MAX_LEN_REPORT: string[] = []
+  for (let i = 0; i < MAX_ACTIONS_SUMMARY_LENGTH / 5; i++) {
+    MAX_LEN_REPORT.push(TEST_LINE_CHAR)
+  }
+
+  it('trims reports that exceed Github limits', () => {
+    const trimmed = trimReport(MAX_LEN_REPORT, 0, DEFAULT_OPTIONS)
+    const trimmedLength = getByteLength(trimmed)
+
+    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expectToBeWithinRangeOfCeiling(trimmedLength, MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE, TEST_LINE_LEN)
+  })
+
+  it('reserves space for prepended string', () => {
+    const prependStringLen = 10
+    const trimmed = trimReport(MAX_LEN_REPORT, prependStringLen, DEFAULT_OPTIONS)
+    const trimmedLength = getByteLength(trimmed)
+
+    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expectToBeWithinRangeOfCeiling(
+      trimmedLength,
+      MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE - prependStringLen,
+      TEST_LINE_LEN
+    )
+  })
+})
+
+describe('getReport', () => {
+  const testCases: TestCaseResult[] = []
+  const testCaseString = '-------------------------' // 25 chars long
+  const FAILURE_ROW_LEN = getByteLength(`  ❌ ${testCaseString}\n`)
+  for (let i = 0; i < MAX_ACTIONS_SUMMARY_LENGTH / 30; i++) {
+    testCases.push(new TestCaseResult(testCaseString, 'failed', 1))
+  }
+  const MAX_LEN_RESULT = [
+    new TestRunResult('run', [new TestSuiteResult('suite', [new TestGroupResult('group', testCases)])])
+  ]
+
+  it('trims reports that exceed Github limits', () => {
+    const trimmed = getReport(MAX_LEN_RESULT, DEFAULT_OPTIONS)
+    const trimmedLength = getByteLength(trimmed)
+
+    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expectToBeWithinRangeOfCeiling(trimmedLength, MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE, FAILURE_ROW_LEN)
+  })
+
+  it('reserves space for prepended string', () => {
+    const prependString = `1 passed, 1 failed and 1 skipped`
+    const prependStringLen = getByteLength(prependString)
+    const trimmed = getReport(MAX_LEN_RESULT, DEFAULT_OPTIONS, prependString)
+    const trimmedLength = getByteLength(trimmed)
+
+    expect(trimmed).toMatch(/has been trimmed\*\*$/)
+    expectToBeWithinRangeOfCeiling(
+      trimmedLength,
+      MAX_ACTIONS_SUMMARY_LENGTH - ALWAYS_RESERVED_SPACE - prependStringLen,
+      FAILURE_ROW_LEN
+    )
+  })
+})
+
+/**
+ * Asserts a subject number is between a ceiling value and a range below it (inclusive)
+ */
+function expectToBeWithinRangeOfCeiling(subject: number, ceiling: number, range: number): void {
+  expect(subject).toBeLessThanOrEqual(ceiling)
+  expect(subject).toBeGreaterThanOrEqual(ceiling - range)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,19 +175,24 @@ class TestReporter {
 
     let baseUrl = ''
     if (this.useActionsSummary) {
-      const summary = getReport(results, {
-        listSuites,
-        listTests,
-        baseUrl,
-        onlySummary,
-        useActionsSummary,
-        badgeTitle,
-        reportTitle
-      })
+      const summaryPrepend = `# ${shortSummary}\n`
+      const summary = getReport(
+        results,
+        {
+          listSuites,
+          listTests,
+          baseUrl,
+          onlySummary,
+          useActionsSummary,
+          badgeTitle,
+          reportTitle
+        },
+        summaryPrepend
+      )
 
       core.info('Summary content:')
       core.info(summary)
-      core.summary.addRaw(`# ${shortSummary}`)
+      core.summary.addRaw(summaryPrepend)
       await core.summary.addRaw(summary).write()
     } else {
       core.info(`Creating check run ${name}`)


### PR DESCRIPTION
In #589 a regression was introduced. A `shortSummary` variable (holding a 35+ byte string) was created outside the `getReport` function and prepended to the step summary, bypassing the Action's truncation logic. For summaries that need truncation, this causes them to still overflow in many cases.

This PR 
- adds an optional input to `getReport` to pass a `prependString`
- adds `prependStringLen` as an input to `trimReport`
- amends the truncation logic of both to account for these extra bytes when present
- adds a test suite to cover the expected truncation behavior for these two functions
  - the length assertions for these test cases are variable based on the length of a single output line rather than exact numbers
  - this is to help avoid them being tied to the byte length of the "Report exceeded GitHub limit" error message, so that it will be easier to change that message in the future

This may resolve issue #654, but needs further confirmation from the reporter.