### PR TITLE
Add missing golang-json reporter to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,7 @@ inputs:
         - dotnet-nunit
         - dotnet-trx
         - flutter-json
+        - golang-json
         - java-junit
         - jest-junit
         - mocha-json


### PR DESCRIPTION
## Summary

Adds the missing `golang-json` reporter to the action.yml documentation. This reporter has been fully implemented in the codebase but was not listed in the action.yml file, making it undiscoverable for users.

## Changes

- Added `golang-json` to the list of supported reporters in `action.yml` (line 32)

## Context

The `golang-json` reporter is fully functional:
- ✅ Implementation exists: `src/parsers/golang-json/golang-json-parser.ts`
- ✅ Registered in main: `src/main.ts:264-265`
- ✅ Tests exist: `__tests__/golang-json.test.ts`
- ✅ Documented in README: `README.md:145`
- ❌ Missing from action.yml (fixed by this PR)

## Impact

This fix will:
- Make Go test support discoverable in the action documentation
- Help users avoid problematic workarounds (converting Go output to JUnit format)
- Align action.yml with the actual implementation and README

## Related Issues

Fixes #689
Related to #189 (users requesting Go support, unaware it exists)

## Test Plan

- The golang-json reporter is already tested in `__tests__/golang-json.test.ts`
- This change only adds documentation, no code changes required
- Users can now use `reporter: golang-json` with `go test -json` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)