### PR TITLE
Create tests for sample JUnit files

### DIFF
--- a/__tests__/__outputs__/junit-basic.md
+++ b/__tests__/__outputs__/junit-basic.md
@@ -1,0 +1,23 @@
+![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%201%20failed-critical)
+|Report|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[fixtures/external/java/junit4-basic.xml](#user-content-r0)|5 ✅|1 ❌||16s|
+## ❌ <a id="user-content-r0" href="#user-content-r0">fixtures/external/java/junit4-basic.xml</a>
+**6** tests were completed in **16s** with **5** passed, **1** failed and **0** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[Tests.Authentication](#user-content-r0s0)|2 ✅|1 ❌||9s|
+|[Tests.Registration](#user-content-r0s1)|3 ✅|||7s|
+### ❌ <a id="user-content-r0s0" href="#user-content-r0s0">Tests.Authentication</a>
+```
+✅ testCase7
+✅ testCase8
+❌ testCase9
+	AssertionError: Assertion error message
+```
+### ✅ <a id="user-content-r0s1" href="#user-content-r0s1">Tests.Registration</a>
+```
+✅ testCase1
+✅ testCase2
+✅ testCase3
+```

--- a/__tests__/__outputs__/junit-complete.md
+++ b/__tests__/__outputs__/junit-complete.md
@@ -1,0 +1,22 @@
+![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed%2C%201%20skipped-critical)
+|Report|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[fixtures/external/java/junit4-complete.xml](#user-content-r0)|5 ✅|2 ❌|1 ⚪|16s|
+## ❌ <a id="user-content-r0" href="#user-content-r0">fixtures/external/java/junit4-complete.xml</a>
+**8** tests were completed in **16s** with **5** passed, **2** failed and **1** skipped.
+|Test suite|Passed|Failed|Skipped|Time|
+|:---|---:|---:|---:|---:|
+|[Tests.Registration](#user-content-r0s0)|5 ✅|2 ❌|1 ⚪|16s|
+### ❌ <a id="user-content-r0s0" href="#user-content-r0s0">Tests.Registration</a>
+```
+✅ testCase1
+✅ testCase2
+✅ testCase3
+⚪ testCase4
+❌ testCase5
+	AssertionError: Expected value did not match.
+❌ testCase6
+	ArithmeticError: Division by zero.
+✅ testCase7
+✅ testCase8
+```

--- a/__tests__/__snapshots__/java-junit.test.ts.snap
+++ b/__tests__/__snapshots__/java-junit.test.ts.snap
@@ -6878,3 +6878,153 @@ at java.lang.Thread.run(Thread.java:748)
   "totalTime": 2126531.0000000005,
 }
 `;
+
+exports[`java-junit tests report from testmo/junitxml basic example matches snapshot 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/junit4-basic.xml",
+  "suites": [
+    TestSuiteResult {
+      "groups": [
+        TestGroupResult {
+          "name": "",
+          "tests": [
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase1",
+              "result": "success",
+              "time": 2113.871,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase2",
+              "result": "success",
+              "time": 1051,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase3",
+              "result": "success",
+              "time": 3441,
+            },
+          ],
+        },
+      ],
+      "name": "Tests.Registration",
+      "totalTime": 6605.870999999999,
+    },
+    TestSuiteResult {
+      "groups": [
+        TestGroupResult {
+          "name": "",
+          "tests": [
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase7",
+              "result": "success",
+              "time": 2508,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase8",
+              "result": "success",
+              "time": 1230.8159999999998,
+            },
+            TestCaseResult {
+              "error": {
+                "details": undefined,
+                "line": undefined,
+                "message": "AssertionError: Assertion error message",
+                "path": undefined,
+              },
+              "name": "testCase9",
+              "result": "failed",
+              "time": 982,
+            },
+          ],
+        },
+      ],
+      "name": "Tests.Authentication",
+      "totalTime": 9076.816,
+    },
+  ],
+  "totalTime": 15682.687,
+}
+`;
+
+exports[`java-junit tests report from testmo/junitxml complete example matches snapshot 1`] = `
+TestRunResult {
+  "path": "fixtures/external/java/junit4-complete.xml",
+  "suites": [
+    TestSuiteResult {
+      "groups": [
+        TestGroupResult {
+          "name": "",
+          "tests": [
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase1",
+              "result": "success",
+              "time": 2436,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase2",
+              "result": "success",
+              "time": 1534,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase3",
+              "result": "success",
+              "time": 822,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase4",
+              "result": "skipped",
+              "time": 0,
+            },
+            TestCaseResult {
+              "error": {
+                "details": undefined,
+                "line": undefined,
+                "message": "AssertionError: Expected value did not match.",
+                "path": undefined,
+              },
+              "name": "testCase5",
+              "result": "failed",
+              "time": 2902.412,
+            },
+            TestCaseResult {
+              "error": {
+                "details": undefined,
+                "line": undefined,
+                "message": "ArithmeticError: Division by zero.",
+                "path": undefined,
+              },
+              "name": "testCase6",
+              "result": "failed",
+              "time": 3819,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase7",
+              "result": "success",
+              "time": 2944,
+            },
+            TestCaseResult {
+              "error": undefined,
+              "name": "testCase8",
+              "result": "success",
+              "time": 1625.275,
+            },
+          ],
+        },
+      ],
+      "name": "Tests.Registration",
+      "totalTime": 16082.687,
+    },
+  ],
+  "totalTime": 16082.687,
+}
+`;

--- a/__tests__/fixtures/external/java/junit4-basic.xml
+++ b/__tests__/fixtures/external/java/junit4-basic.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is a basic JUnit-style XML example to highlight the basis structure.
+
+Example by Testmo. Copyright 2023 Testmo GmbH. All rights reserved.
+Testmo test management software - https://www.testmo.com/
+-->
+<testsuites time="15.682687">
+    <testsuite name="Tests.Registration" time="6.605871">
+        <testcase name="testCase1" classname="Tests.Registration" time="2.113871" />
+        <testcase name="testCase2" classname="Tests.Registration" time="1.051" />
+        <testcase name="testCase3" classname="Tests.Registration" time="3.441" />
+    </testsuite>
+    <testsuite name="Tests.Authentication" time="9.076816">
+        <!-- Java JUni4 XML files does not nest <testsuite> elements -->
+        <!--
+        <testsuite name="Tests.Authentication.Login" time="4.356">
+            <testcase name="testCase4" classname="Tests.Authentication.Login" time="2.244" />
+            <testcase name="testCase5" classname="Tests.Authentication.Login" time="0.781" />
+            <testcase name="testCase6" classname="Tests.Authentication.Login" time="1.331" />
+        </testsuite>
+        -->
+        <testcase name="testCase7" classname="Tests.Authentication" time="2.508" />
+        <testcase name="testCase8" classname="Tests.Authentication" time="1.230816" />
+        <testcase name="testCase9" classname="Tests.Authentication" time="0.982">
+            <failure message="Assertion error message" type="AssertionError">
+                <!-- Call stack printed here -->
+            </failure>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/__tests__/fixtures/external/java/junit4-complete.xml
+++ b/__tests__/fixtures/external/java/junit4-complete.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This is a JUnit-style XML example with commonly used tags and attributes.
+
+Example by Testmo. Copyright 2023 Testmo GmbH. All rights reserved.
+Testmo test management software - https://www.testmo.com/
+-->
+
+<!-- <testsuites> Usually the root element of a JUnit XML file. Some tools leave out
+the <testsuites> element if there is only a single top-level <testsuite> element (which
+is then used as the root element).
+
+name        Name of the entire test run
+tests       Total number of tests in this file
+failures    Total number of failed tests in this file
+errors      Total number of errored tests in this file
+skipped     Total number of skipped tests in this file
+assertions  Total number of assertions for all tests in this file
+time        Aggregated time of all tests in this file in seconds
+timestamp   Date and time of when the test run was executed (in ISO 8601 format)
+-->
+<testsuites name="Test run" tests="8" failures="1" errors="1" skipped="1"
+    assertions="20" time="16.082687" timestamp="2021-04-02T15:48:23">
+
+    <!-- <testsuite> A test suite usually represents a class, folder or group of tests.
+    There can be many test suites in an XML file, and there can be test suites under other
+    test suites.
+
+    name        Name of the test suite (e.g. class name or folder name)
+    tests       Total number of tests in this suite
+    failures    Total number of failed tests in this suite
+    errors      Total number of errored tests in this suite
+    skipped     Total number of skipped tests in this suite
+    assertions  Total number of assertions for all tests in this suite
+    time        Aggregated time of all tests in this file in seconds
+    timestamp   Date and time of when the test suite was executed (in ISO 8601 format)
+    file        Source code file of this test suite
+    -->
+    <testsuite name="Tests.Registration" tests="8" failures="1" errors="1" skipped="1"
+        assertions="20" time="16.082687" timestamp="2021-04-02T15:48:23"
+        file="tests/registration.code">
+
+        <!-- <properties> Test suites (and test cases, see below) can have additional
+        properties such as environment variables or version numbers. -->
+        <properties>
+            <!-- <property> Each property has a name and value. Some tools also support
+            properties with text values instead of value attributes. -->
+            <property name="version" value="1.774" />
+            <property name="commit" value="ef7bebf" />
+            <property name="browser" value="Google Chrome" />
+            <property name="ci" value="https://github.com/actions/runs/1234" />
+            <property name="config">
+                Config line #1
+                Config line #2
+                Config line #3
+            </property>
+        </properties>
+
+        <!-- <system-out> Optionally data written to standard out for the suite.
+        Also supported on a test case level, see below. -->
+        <system-out>Data written to standard out.</system-out>
+
+        <!-- <system-err> Optionally data written to standard error for the suite.
+        Also supported on a test case level, see below. -->
+        <system-err>Data written to standard error.</system-err>
+
+        <!-- <testcase> There are one or more test cases in a test suite. A test passed
+        if there isn't an additional result element (skipped, failure, error).
+
+        name        The name of this test case, often the method name
+        classname   The name of the parent class/folder, often the same as the suite's name
+        assertions  Number of assertions checked during test case execution
+        time        Execution time of the test in seconds
+        file        Source code file of this test case
+        line        Source code line number of the start of this test case
+        -->
+        <testcase name="testCase1" classname="Tests.Registration" assertions="2"
+            time="2.436" file="tests/registration.code" line="24" />
+        <testcase name="testCase2" classname="Tests.Registration" assertions="6"
+            time="1.534" file="tests/registration.code" line="62" />
+        <testcase name="testCase3" classname="Tests.Registration" assertions="3"
+            time="0.822" file="tests/registration.code" line="102" />
+
+        <!-- Example of a test case that was skipped -->
+        <testcase name="testCase4" classname="Tests.Registration" assertions="0"
+            time="0" file="tests/registration.code" line="164">
+            <!-- <skipped> Indicates that the test was not executed. Can have an optional
+            message describing why the test was skipped. -->
+            <skipped message="Test was skipped." />
+        </testcase>
+
+        <!-- Example of a test case that failed. -->
+        <testcase name="testCase5" classname="Tests.Registration" assertions="2"
+            time="2.902412" file="tests/registration.code" line="202">
+            <!-- <failure> The test failed because one of the assertions/checks failed.
+            Can have a message and failure type, often the assertion type or class. The text
+            content of the element often includes the failure description or stack trace. -->
+            <failure message="Expected value did not match." type="AssertionError">
+                <!-- Failure description or stack trace -->
+            </failure>
+        </testcase>
+
+        <!-- Example of a test case that had errors. -->
+        <testcase name="testCase6" classname="Tests.Registration" assertions="0"
+            time="3.819" file="tests/registration.code" line="235">
+            <!-- <error> The test had an unexpected error during execution. Can have a
+            message and error type, often the exception type or class. The text
+            content of the element often includes the error description or stack trace. -->
+            <error message="Division by zero." type="ArithmeticError">
+                <!-- Error description or stack trace -->
+            </error>
+        </testcase>
+
+        <!-- Example of a test case with outputs. -->
+        <testcase name="testCase7" classname="Tests.Registration" assertions="3"
+            time="2.944" file="tests/registration.code" line="287">
+            <!-- <system-out> Optional data written to standard out for the test case. -->
+            <system-out>Data written to standard out.</system-out>
+
+            <!-- <system-err> Optional data written to standard error for the test case. -->
+            <system-err>Data written to standard error.</system-err>
+        </testcase>
+
+        <!-- Example of a test case with properties -->
+        <testcase name="testCase8" classname="Tests.Registration" assertions="4"
+            time="1.625275" file="tests/registration.code" line="302">
+            <!-- <properties> Some tools also support properties for test cases. -->
+            <properties>
+                <property name="priority" value="high" />
+                <property name="language" value="english" />
+                <property name="author" value="Adrian" />
+                <property name="attachment" value="screenshots/dashboard.png" />
+                <property name="attachment" value="screenshots/users.png" />
+                <property name="description">
+                    This text describes the purpose of this test case and provides
+                    an overview of what the test does and how it works.
+                </property>
+            </properties>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/__tests__/java-junit.test.ts
+++ b/__tests__/java-junit.test.ts
@@ -73,6 +73,46 @@ describe('java-junit tests', () => {
     fs.writeFileSync(outputPath, report)
   })
 
+  it('report from testmo/junitxml basic example matches snapshot', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'junit4-basic.xml')
+    const outputPath = path.join(__dirname, '__outputs__', 'junit-basic.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result])
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+
+  it('report from testmo/junitxml complete example matches snapshot', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'junit4-complete.xml')
+    const outputPath = path.join(__dirname, '__outputs__', 'junit-complete.md')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new JavaJunitParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+    expect(result).toMatchSnapshot()
+
+    const report = getReport([result])
+    fs.mkdirSync(path.dirname(outputPath), {recursive: true})
+    fs.writeFileSync(outputPath, report)
+  })
+
   it('parses empty failures in test results', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'empty_failures.xml')
     const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))


### PR DESCRIPTION
Two unit tests for parsing sample `junit-basic.xml` and `junit-complete.xml` samples from https://github.com/testmoapp/junitxml/

This PR exercise existing implementation which does not support nested `<testsuite>` reports.

### Nested testsuite tests are not reported

In `junit-basic.xml`, there's a nested testsuite:

```xml
<testsuite name="Tests.Authentication" time="9.076816">
    <testsuite name="Tests.Authentication.Login" time="4.356">
        <testcase name="testCase4" .../>
        <testcase name="testCase5" .../>
        <testcase name="testCase6" .../>
    </testsuite>
    ...
</testsuite>
```

The parser at[ src/parsers/java-junit/java-junit-parser.ts:79-82](https://github.com/dorny/test-reporter/blob/ee446707ff3bdadb3c039ff1af4286a09acb79c6/src/parsers/java-junit/java-junit-parser.ts#L79-L82) only processes direct `<testcase>` children of a `<testsuite>`, not nested `<testsuite>` elements. As a result:
  - 3 test cases (`testCase4`, `testCase5`, `testCase6`) are silently dropped
  - The expected output shows `"5 passed, 1 failed" (6 total)`, but the XML has 9 test cases
