### PR TITLE
doc: Updated GitHub actions to latest versions in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4     # checkout the repo
+      - uses: actions/checkout@v6     # checkout the repo
       - run: npm ci                   # install packages
       - run: npm test                 # run tests (configured to use jest-junit reporter)
 
@@ -78,10 +78,10 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4         # checkout the repo
+      - uses: actions/checkout@v6         # checkout the repo
       - run: npm ci                       # install packages
       - run: npm test                     # run tests (configured to use jest-junit reporter)
-      - uses: actions/upload-artifact@v4  # upload test results
+      - uses: actions/upload-artifact@v7  # upload test results
         if: ${{ !cancelled() }}           # run this step even if previous step failed
         with:
           name: test-results


### PR DESCRIPTION
The example of how to include the reporter in the CI/CD workflow used older versions of GitHub actions. This bumps the versions to the latest supported as of April 2026 so that people who copy these into their own pipelines use more up-to-date versions.