### PR TITLE
Add generated summary action output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.0
 * Feature: Add `list-files` input to control test report file listing https://github.com/dorny/test-reporter/pull/773
-* Feature: Add `summary` output with the generated summary in Markdown format https://github.com/dorny/test-reporter/pull/772
+* Feature: Add `summary_file` output with the path to the generated summary in Markdown format https://github.com/dorny/test-reporter/pull/772
 
 ## 3.0.0
 * Feature: Use NodeJS 24 LTS as default runtime https://github.com/dorny/test-reporter/pull/738

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1.0
 * Feature: Add `list-files` input to control test report file listing https://github.com/dorny/test-reporter/pull/773
+* Feature: Add `summary` output with the generated summary in Markdown format https://github.com/dorny/test-reporter/pull/772
 
 ## 3.0.0
 * Feature: Use NodeJS 24 LTS as default runtime https://github.com/dorny/test-reporter/pull/738

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ jobs:
 | time       | Test execution time [ms] |
 | url        | Check run URL            |
 | url_html   | Check run URL HTML       |
-| summary    | Generated test report summary in Markdown format |
+| summary_file | Path to a file containing the generated test report summary in Markdown format |
 | slug_prefix| Random anchor links slug prefix generated for the summary headers |
 
 ## Supported formats

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ jobs:
 | time       | Test execution time [ms] |
 | url        | Check run URL            |
 | url_html   | Check run URL HTML       |
+| summary    | Generated test report summary in Markdown format |
 | slug_prefix| Random anchor links slug prefix generated for the summary headers |
 
 ## Supported formats

--- a/action.yml
+++ b/action.yml
@@ -130,6 +130,8 @@ outputs:
     description: Check run URL
   url_html:
     description: Check run URL HTML
+  summary:
+    description: Generated test report summary in Markdown format
   slug_prefix:
     description: Random prefix added to generated report anchor slugs for this action run
 runs:

--- a/action.yml
+++ b/action.yml
@@ -130,8 +130,8 @@ outputs:
     description: Check run URL
   url_html:
     description: Check run URL HTML
-  summary:
-    description: Generated test report summary in Markdown format
+  summary_file:
+    description: Path to a file containing the generated test report summary in Markdown format
   slug_prefix:
     description: Random prefix added to generated report anchor slugs for this action run
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -59089,6 +59089,7 @@ class TestReporter {
             }, shortSummary);
             info('Summary content:');
             info(summary);
+            setOutput('summary', summary);
             await summary_summary.addRaw(summary).write();
         }
         else {
@@ -59119,6 +59120,7 @@ class TestReporter {
             });
             info('Creating annotations');
             const annotations = getAnnotations(results, this.maxAnnotations);
+            setOutput('summary', summary);
             const isFailed = this.failOnError && results.some(tr => tr.result === 'failed');
             const conclusion = isFailed ? 'failure' : 'success';
             info(`Updating check run conclusion (${conclusion}) and output`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -16015,7 +16015,7 @@ module.exports.fetch = async function fetch (init, options = undefined) {
 }
 module.exports.Headers = __nccwpck_require__(660).Headers
 module.exports.Response = __nccwpck_require__(9051).Response
-module.exports.Request = __nccwpck_require__(2348).Request
+module.exports.Request = __nccwpck_require__(9967).Request
 module.exports.FormData = __nccwpck_require__(5910).FormData
 module.exports.File = globalThis.File ?? (__nccwpck_require__(4573).File)
 module.exports.FileReader = __nccwpck_require__(8355).FileReader
@@ -27430,7 +27430,7 @@ const { urlEquals, getFieldValues } = __nccwpck_require__(6798)
 const { kEnumerableProperty, isDisturbed } = __nccwpck_require__(3440)
 const { webidl } = __nccwpck_require__(5893)
 const { Response, cloneResponse, fromInnerResponse } = __nccwpck_require__(9051)
-const { Request, fromInnerRequest } = __nccwpck_require__(2348)
+const { Request, fromInnerRequest } = __nccwpck_require__(9967)
 const { kState } = __nccwpck_require__(3627)
 const { fetching } = __nccwpck_require__(4398)
 const { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = __nccwpck_require__(3168)
@@ -29744,7 +29744,7 @@ module.exports = {
 
 const { pipeline } = __nccwpck_require__(7075)
 const { fetching } = __nccwpck_require__(4398)
-const { makeRequest } = __nccwpck_require__(2348)
+const { makeRequest } = __nccwpck_require__(9967)
 const { webidl } = __nccwpck_require__(5893)
 const { EventSourceStream } = __nccwpck_require__(4031)
 const { parseMIMEType } = __nccwpck_require__(1900)
@@ -33368,7 +33368,7 @@ const {
   fromInnerResponse
 } = __nccwpck_require__(9051)
 const { HeadersList } = __nccwpck_require__(660)
-const { Request, cloneRequest } = __nccwpck_require__(2348)
+const { Request, cloneRequest } = __nccwpck_require__(9967)
 const zlib = __nccwpck_require__(8522)
 const {
   bytesMatch,
@@ -35632,7 +35632,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 2348:
+/***/ 9967:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /* globals AbortController */
@@ -40814,7 +40814,7 @@ const {
 const { fireEvent, failWebsocketConnection, isClosing, isClosed, isEstablished, parseExtensions } = __nccwpck_require__(8625)
 const { channels } = __nccwpck_require__(2414)
 const { CloseEvent } = __nccwpck_require__(5188)
-const { makeRequest } = __nccwpck_require__(2348)
+const { makeRequest } = __nccwpck_require__(9967)
 const { fetching } = __nccwpck_require__(4398)
 const { Headers, getHeadersList } = __nccwpck_require__(660)
 const { getDecodeSplit } = __nccwpck_require__(3168)
@@ -56445,6 +56445,12 @@ function getOctokit(token, options, ...additionalPlugins) {
 //# sourceMappingURL=github.js.map
 // EXTERNAL MODULE: external "node:crypto"
 var external_node_crypto_ = __nccwpck_require__(7598);
+;// CONCATENATED MODULE: external "node:fs"
+const external_node_fs_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:fs");
+;// CONCATENATED MODULE: external "node:os"
+const external_node_os_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:os");
+;// CONCATENATED MODULE: external "node:path"
+const external_node_path_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:path");
 // EXTERNAL MODULE: ./node_modules/adm-zip/adm-zip.js
 var adm_zip = __nccwpck_require__(1316);
 // EXTERNAL MODULE: ./node_modules/picomatch/index.js
@@ -58936,6 +58942,9 @@ class NetteTesterJunitParser {
 
 
 
+
+
+
 async function main() {
     try {
         const testReporter = new TestReporter();
@@ -59089,7 +59098,7 @@ class TestReporter {
             }, shortSummary);
             info('Summary content:');
             info(summary);
-            setOutput('summary', summary);
+            this.writeSummaryFile(summary);
             await summary_summary.addRaw(summary).write();
         }
         else {
@@ -59120,7 +59129,7 @@ class TestReporter {
             });
             info('Creating annotations');
             const annotations = getAnnotations(results, this.maxAnnotations);
-            setOutput('summary', summary);
+            this.writeSummaryFile(summary);
             const isFailed = this.failOnError && results.some(tr => tr.result === 'failed');
             const conclusion = isFailed ? 'failure' : 'success';
             info(`Updating check run conclusion (${conclusion}) and output`);
@@ -59142,6 +59151,13 @@ class TestReporter {
             setOutput('url_html', resp.data.html_url);
         }
         return results;
+    }
+    writeSummaryFile(summary) {
+        const dir = process.env.RUNNER_TEMP || (0,external_node_os_namespaceObject.tmpdir)();
+        const file = (0,external_node_path_namespaceObject.join)(dir, `test-reporter-summary-${(0,external_node_crypto_.randomBytes)(8).toString('hex')}.md`);
+        (0,external_node_fs_namespaceObject.writeFileSync)(file, summary);
+        info(`Summary written to ${file}`);
+        setOutput('summary_file', file);
     }
     getParser(reporter, options) {
         switch (reporter) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,6 +221,7 @@ class TestReporter {
 
       core.info('Summary content:')
       core.info(summary)
+      core.setOutput('summary', summary)
       await core.summary.addRaw(summary).write()
     } else {
       core.info(`Creating check run ${name}`)
@@ -252,6 +253,7 @@ class TestReporter {
 
       core.info('Creating annotations')
       const annotations = getAnnotations(results, this.maxAnnotations)
+      core.setOutput('summary', summary)
 
       const isFailed = this.failOnError && results.some(tr => tr.result === 'failed')
       const conclusion = isFailed ? 'failure' : 'success'

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,9 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {GitHub} from '@actions/github/lib/utils'
 import {randomBytes} from 'node:crypto'
+import {writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 
 import {ArtifactProvider} from './input-providers/artifact-provider.js'
 import {LocalFileProvider} from './input-providers/local-file-provider.js'
@@ -221,7 +224,7 @@ class TestReporter {
 
       core.info('Summary content:')
       core.info(summary)
-      core.setOutput('summary', summary)
+      this.writeSummaryFile(summary)
       await core.summary.addRaw(summary).write()
     } else {
       core.info(`Creating check run ${name}`)
@@ -253,7 +256,7 @@ class TestReporter {
 
       core.info('Creating annotations')
       const annotations = getAnnotations(results, this.maxAnnotations)
-      core.setOutput('summary', summary)
+      this.writeSummaryFile(summary)
 
       const isFailed = this.failOnError && results.some(tr => tr.result === 'failed')
       const conclusion = isFailed ? 'failure' : 'success'
@@ -278,6 +281,14 @@ class TestReporter {
     }
 
     return results
+  }
+
+  writeSummaryFile(summary: string): void {
+    const dir = process.env.RUNNER_TEMP || tmpdir()
+    const file = join(dir, `test-reporter-summary-${randomBytes(8).toString('hex')}.md`)
+    writeFileSync(file, summary)
+    core.info(`Summary written to ${file}`)
+    core.setOutput('summary_file', file)
   }
 
   getParser(reporter: string, options: ParseOptions): TestParser {


### PR DESCRIPTION
## Summary

This creates a focused replacement for #659, which is blocked because the original PR comes from an uneditable fork branch.

- Adds a `summary_file` action output with the path to a Markdown file containing the generated test report summary.
- The file is written to a unique path under `$RUNNER_TEMP` (falls back to OS temp dir) so downstream steps can read the full report without hitting GitHub Actions' per-step output size limits.
- Sets the output in both Actions Summary mode and check-run mode.
- Rebuilds `dist/index.js` from the source change.

Downstream usage example:

```yaml
- uses: dorny/test-reporter@v3
  id: report
  with: { ... }
- run: cat "${{ steps.report.outputs.summary_file }}" >> $GITHUB_STEP_SUMMARY
```

## Verification

- `npm run build`
- `npm run package`
- `npm run lint`
- `npm test -- --runInBand`

Closes #659.