### PR TITLE
Fix java-junit annotation resolution for issue #678

### DIFF
--- a/__tests__/fixtures/external/java/module-prefix-failure.xml
+++ b/__tests__/fixtures/external/java/module-prefix-failure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.example.MyClassTest" tests="1" failures="1" time="0.01">
+  <testcase name="testMethod" classname="com.example.MyClassTest" time="0.01">
+    <failure message="expected true but was false"><![CDATA[java.lang.AssertionError: expected true but was false
+at java.base/com.example.MyClassTest.testMethod(MyClassTest.java:10)
+]]></failure>
+  </testcase>
+</testsuite>

--- a/__tests__/fixtures/external/java/multi-module-failure.xml
+++ b/__tests__/fixtures/external/java/multi-module-failure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.sgcib.cops.common.utils.MaturityUtilsUnitTest" tests="1" failures="1" time="0.01">
+  <testcase name="testtemporaryfailure" classname="com.sgcib.cops.common.utils.MaturityUtilsUnitTest" time="0.01">
+    <failure message="expected true but was false"><![CDATA[java.lang.AssertionError: expected true but was false
+at com.sgcib.cops.common.utils.MaturityUtilsUnitTest.testtemporaryfailure(MaturityUtilsUnitTest.java:21)
+]]></failure>
+  </testcase>
+</testsuite>

--- a/__tests__/fixtures/external/java/spring-gradle-failure.xml
+++ b/__tests__/fixtures/external/java/spring-gradle-failure.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.victor.paymentreporting.app.PowerDroidControllerTest" tests="3" skipped="0" failures="1" errors="0" timestamp="2026-05-28T22:31:02" hostname="FWGV7J6Q00" time="2.638">
+  <properties/>
+  <testcase name="echoHealthCheckReturnsHealthyMessage()" classname="com.victor.paymentreporting.app.PowerDroidControllerTest" time="2.536"/>
+  <testcase name="helloReturnsPowerDroidMessage()" classname="com.victor.paymentreporting.app.PowerDroidControllerTest" time="0.03"/>
+  <testcase name="failsToDemonstrateJUnitAnnotations()" classname="com.victor.paymentreporting.app.PowerDroidControllerTest" time="0.056">
+    <failure message="java.lang.AssertionError: Response content&#10;Expected: a string containing &quot;NOT_GONK&quot;&#10;     but: was &quot;*Low mechanical hum* GONK. I am a power droid. My batteries are fully charged. GONK.&quot;" type="java.lang.AssertionError">java.lang.AssertionError: Response content
+Expected: a string containing &quot;NOT_GONK&quot;
+     but: was &quot;*Low mechanical hum* GONK. I am a power droid. My batteries are fully charged. GONK.&quot;
+	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
+	at org.springframework.test.web.servlet.result.ContentResultMatchers.lambda$string$3(ContentResultMatchers.java:141)
+	at org.springframework.test.web.servlet.MockMvc$1.andExpect(MockMvc.java:214)
+	at com.victor.paymentreporting.app.PowerDroidControllerTest.failsToDemonstrateJUnitAnnotations(PowerDroidControllerTest.java:37)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
+	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
+</failure>
+  </testcase>
+</testsuite>

--- a/__tests__/fixtures/external/java/uppercase-package-failure.xml
+++ b/__tests__/fixtures/external/java/uppercase-package-failure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.MyCompany.utils.ExampleTest" tests="1" failures="1" time="0.01">
+  <testcase name="testSomething" classname="com.MyCompany.utils.ExampleTest" time="0.01">
+    <failure message="expected true but was false"><![CDATA[java.lang.AssertionError: expected true but was false
+at com.MyCompany.utils.ExampleTest.testSomething(ExampleTest.java:15)
+]]></failure>
+  </testcase>
+</testsuite>

--- a/__tests__/java-junit.test.ts
+++ b/__tests__/java-junit.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import {JavaJunitParser} from '../src/parsers/java-junit/java-junit-parser.js'
 import {ParseOptions} from '../src/test-parser.js'
 import {DEFAULT_OPTIONS, getReport} from '../src/report/get-report.js'
+import {getAnnotations} from '../src/report/get-annotations.js'
 import {normalizeFilePath} from '../src/utils/path-utils.js'
 
 import {fileURLToPath} from 'url'
@@ -196,5 +197,59 @@ describe('java-junit tests', () => {
     })
     // Report should have the title as the first line
     expect(report).toMatch(/^# My Custom Title\n/)
+  })
+
+  it('resolves source file path in multi-module Maven projects', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'multi-module-failure.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+    const trackedFiles = [
+      'core/common/src/test/java/com/sgcib/cops/common/utils/MaturityUtilsUnitTest.java'
+    ]
+
+    const parser = new JavaJunitParser({parseErrors: true, trackedFiles})
+    const result = await parser.parse(filePath, fileContent)
+    const failedTest = result.suites[0].groups[0].tests[0]
+
+    expect(failedTest.result).toBe('failed')
+    expect(failedTest.error?.path).toBe(
+      'core/common/src/test/java/com/sgcib/cops/common/utils/MaturityUtilsUnitTest.java'
+    )
+    expect(failedTest.error?.line).toBe(21)
+
+    const annotations = getAnnotations([result], 10)
+    expect(annotations).toHaveLength(1)
+    expect(annotations[0].path).toBe(
+      'core/common/src/test/java/com/sgcib/cops/common/utils/MaturityUtilsUnitTest.java'
+    )
+    expect(annotations[0].start_line).toBe(21)
+  })
+
+  it('resolves source file path when package name contains uppercase letters', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'uppercase-package-failure.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+    const trackedFiles = ['module-a/src/test/java/com/MyCompany/utils/ExampleTest.java']
+
+    const parser = new JavaJunitParser({parseErrors: true, trackedFiles})
+    const result = await parser.parse(filePath, fileContent)
+    const failedTest = result.suites[0].groups[0].tests[0]
+
+    expect(failedTest.error?.path).toBe('module-a/src/test/java/com/MyCompany/utils/ExampleTest.java')
+    expect(failedTest.error?.line).toBe(15)
+  })
+
+  it('resolves source file path when stack trace contains Java 9 module prefix', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'module-prefix-failure.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+    const trackedFiles = ['service-app/src/test/java/com/example/MyClassTest.java']
+
+    const parser = new JavaJunitParser({parseErrors: true, trackedFiles})
+    const result = await parser.parse(filePath, fileContent)
+    const failedTest = result.suites[0].groups[0].tests[0]
+
+    expect(failedTest.error?.path).toBe('service-app/src/test/java/com/example/MyClassTest.java')
+    expect(failedTest.error?.line).toBe(10)
   })
 })

--- a/__tests__/java-junit.test.ts
+++ b/__tests__/java-junit.test.ts
@@ -252,4 +252,34 @@ describe('java-junit tests', () => {
     expect(failedTest.error?.path).toBe('service-app/src/test/java/com/example/MyClassTest.java')
     expect(failedTest.error?.line).toBe(10)
   })
+
+  it('produces a GitHub annotation for a Gradle + Spring Boot JUnit5 failure', async () => {
+    // Reproduces https://github.com/victor-fi/release-demo PRs 7 & 8: a real Gradle/Spring
+    // failure report whose stack trace interleaves `java.base/...` module-prefixed frames
+    // around the actual test frame. The annotation must resolve to the tracked source file.
+    const fixturePath = path.join(__dirname, 'fixtures', 'external', 'java', 'spring-gradle-failure.xml')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+    const trackedFiles = [
+      'service-app/src/test/java/com/victor/paymentreporting/app/PowerDroidControllerTest.java'
+    ]
+
+    const parser = new JavaJunitParser({parseErrors: true, trackedFiles})
+    const result = await parser.parse(filePath, fileContent)
+    const failedTest = result.suites[0].groups[0].tests.find(t => t.result === 'failed')
+
+    expect(failedTest).toBeDefined()
+    expect(failedTest?.error?.path).toBe(
+      'service-app/src/test/java/com/victor/paymentreporting/app/PowerDroidControllerTest.java'
+    )
+    expect(failedTest?.error?.line).toBe(37)
+
+    const annotations = getAnnotations([result], 10)
+    expect(annotations).toHaveLength(1)
+    expect(annotations[0].annotation_level).toBe('failure')
+    expect(annotations[0].path).toBe(
+      'service-app/src/test/java/com/victor/paymentreporting/app/PowerDroidControllerTest.java'
+    )
+    expect(annotations[0].start_line).toBe(37)
+  })
 })

--- a/__tests__/java-stack-trace-element-parser.test.ts
+++ b/__tests__/java-stack-trace-element-parser.test.ts
@@ -59,6 +59,17 @@ describe('parseStackTraceLine tests', () => {
           lineStr: '101'
         })
       })
+
+      it('with module only', async () => {
+        const line = 'at java.base/java.lang.Thread.getStackTrace(Thread.java:1606)'
+        expect(parseStackTraceElement(line)).toEqual({
+          classLoader: undefined,
+          moduleNameAndVersion: 'java.base',
+          tracePath: 'java.lang.Thread.getStackTrace',
+          fileName: 'Thread.java',
+          lineStr: '1606'
+        })
+      })
     })
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -57956,13 +57956,15 @@ class GolangJsonParser {
 ;// CONCATENATED MODULE: ./lib/parsers/java-junit/java-stack-trace-element-parser.js
 // classloader and module name are optional:
 // at <CLASSLOADER>/<MODULE_NAME_AND_VERSION>/<FULLY_QUALIFIED_METHOD_NAME>(<FILE_NAME>:<LINE_NUMBER>)
+// at <CLASSLOADER>//<FULLY_QUALIFIED_METHOD_NAME>(<FILE_NAME>:<LINE_NUMBER>)
+// at <MODULE_NAME>/<FULLY_QUALIFIED_METHOD_NAME>(<FILE_NAME>:<LINE_NUMBER>)
 // https://github.com/eclipse-openj9/openj9/issues/11452#issuecomment-754946992
-const re = /^\s*at (\S+\/\S*\/)?(.*)\((.*):(\d+)\)$/;
+const re = /^\s*at (.*)\((.*):(\d+)\)$/;
 function parseStackTraceElement(stackTraceLine) {
     const match = stackTraceLine.match(re);
     if (match !== null) {
-        const [_, maybeClassLoaderAndModuleNameAndVersion, tracePath, fileName, lineStr] = match;
-        const { classLoader, moduleNameAndVersion } = parseClassLoaderAndModule(maybeClassLoaderAndModuleNameAndVersion);
+        const [, beforeParen, fileName, lineStr] = match;
+        const { classLoader, moduleNameAndVersion, tracePath } = parseClassLoaderModuleAndTracePath(beforeParen);
         return {
             classLoader,
             moduleNameAndVersion,
@@ -57973,17 +57975,35 @@ function parseStackTraceElement(stackTraceLine) {
     }
     return undefined;
 }
-function parseClassLoaderAndModule(maybeClassLoaderAndModuleNameAndVersion) {
-    if (maybeClassLoaderAndModuleNameAndVersion) {
-        const res = maybeClassLoaderAndModuleNameAndVersion.split('/');
-        const classLoader = res[0];
-        let moduleNameAndVersion = res[1];
-        if (moduleNameAndVersion === '') {
-            moduleNameAndVersion = undefined;
-        }
-        return { classLoader, moduleNameAndVersion };
+function parseClassLoaderModuleAndTracePath(beforeParen) {
+    const slashIndex = beforeParen.indexOf('/');
+    if (slashIndex === -1) {
+        return { tracePath: beforeParen };
     }
-    return { classLoader: undefined, moduleNameAndVersion: undefined };
+    const firstSegment = beforeParen.substring(0, slashIndex);
+    const afterFirstSlash = beforeParen.substring(slashIndex + 1);
+    // classloader//method
+    if (afterFirstSlash.startsWith('/')) {
+        return {
+            classLoader: firstSegment,
+            tracePath: afterFirstSlash.substring(1)
+        };
+    }
+    const secondSlashIndex = afterFirstSlash.indexOf('/');
+    if (secondSlashIndex !== -1) {
+        const secondSegment = afterFirstSlash.substring(0, secondSlashIndex);
+        const tracePath = afterFirstSlash.substring(secondSlashIndex + 1);
+        return {
+            classLoader: firstSegment,
+            moduleNameAndVersion: secondSegment,
+            tracePath
+        };
+    }
+    // module/method (e.g. java.base/java.lang.Thread.getStackTrace)
+    return {
+        moduleNameAndVersion: firstSegment,
+        tracePath: afterFirstSlash
+    };
 }
 
 ;// CONCATENATED MODULE: ./lib/parsers/java-junit/java-junit-parser.js
@@ -58141,13 +58161,15 @@ class JavaJunitParser {
         if (files === undefined) {
             return undefined;
         }
-        // Remove class name and method name from trace.
-        // Take parts until first item with capital letter - package names are lowercase while class name is CamelCase.
-        const packageParts = tracePath.split(/\./g);
-        const packageIndex = packageParts.findIndex(part => part[0] <= 'Z');
-        if (packageIndex !== -1) {
-            packageParts.splice(packageIndex, packageParts.length - packageIndex);
+        // Remove class name and method name from trace path.
+        // tracePath format: com.package.ClassName.methodName
+        const traceParts = tracePath.split(/\./g);
+        if (traceParts.length < 2) {
+            return undefined;
         }
+        traceParts.pop(); // method name
+        traceParts.pop(); // class name (may include $ for inner classes)
+        const packageParts = traceParts;
         if (packageParts.length === 0) {
             return undefined;
         }

--- a/src/parsers/java-junit/java-junit-parser.ts
+++ b/src/parsers/java-junit/java-junit-parser.ts
@@ -179,13 +179,16 @@ export class JavaJunitParser implements TestParser {
       return undefined
     }
 
-    // Remove class name and method name from trace.
-    // Take parts until first item with capital letter - package names are lowercase while class name is CamelCase.
-    const packageParts = tracePath.split(/\./g)
-    const packageIndex = packageParts.findIndex(part => part[0] <= 'Z')
-    if (packageIndex !== -1) {
-      packageParts.splice(packageIndex, packageParts.length - packageIndex)
+    // Remove class name and method name from trace path.
+    // tracePath format: com.package.ClassName.methodName
+    const traceParts = tracePath.split(/\./g)
+    if (traceParts.length < 2) {
+      return undefined
     }
+
+    traceParts.pop() // method name
+    traceParts.pop() // class name (may include $ for inner classes)
+    const packageParts = traceParts
 
     if (packageParts.length === 0) {
       return undefined

--- a/src/parsers/java-junit/java-stack-trace-element-parser.ts
+++ b/src/parsers/java-junit/java-stack-trace-element-parser.ts
@@ -8,14 +8,16 @@ export interface StackTraceElement {
 
 // classloader and module name are optional:
 // at <CLASSLOADER>/<MODULE_NAME_AND_VERSION>/<FULLY_QUALIFIED_METHOD_NAME>(<FILE_NAME>:<LINE_NUMBER>)
+// at <CLASSLOADER>//<FULLY_QUALIFIED_METHOD_NAME>(<FILE_NAME>:<LINE_NUMBER>)
+// at <MODULE_NAME>/<FULLY_QUALIFIED_METHOD_NAME>(<FILE_NAME>:<LINE_NUMBER>)
 // https://github.com/eclipse-openj9/openj9/issues/11452#issuecomment-754946992
-const re = /^\s*at (\S+\/\S*\/)?(.*)\((.*):(\d+)\)$/
+const re = /^\s*at (.*)\((.*):(\d+)\)$/
 
 export function parseStackTraceElement(stackTraceLine: string): StackTraceElement | undefined {
   const match = stackTraceLine.match(re)
   if (match !== null) {
-    const [_, maybeClassLoaderAndModuleNameAndVersion, tracePath, fileName, lineStr] = match
-    const {classLoader, moduleNameAndVersion} = parseClassLoaderAndModule(maybeClassLoaderAndModuleNameAndVersion)
+    const [, beforeParen, fileName, lineStr] = match
+    const {classLoader, moduleNameAndVersion, tracePath} = parseClassLoaderModuleAndTracePath(beforeParen)
     return {
       classLoader,
       moduleNameAndVersion,
@@ -27,18 +29,41 @@ export function parseStackTraceElement(stackTraceLine: string): StackTraceElemen
   return undefined
 }
 
-function parseClassLoaderAndModule(maybeClassLoaderAndModuleNameAndVersion?: string): {
+function parseClassLoaderModuleAndTracePath(beforeParen: string): {
   classLoader?: string
   moduleNameAndVersion?: string
+  tracePath: string
 } {
-  if (maybeClassLoaderAndModuleNameAndVersion) {
-    const res = maybeClassLoaderAndModuleNameAndVersion.split('/')
-    const classLoader = res[0]
-    let moduleNameAndVersion: string | undefined = res[1]
-    if (moduleNameAndVersion === '') {
-      moduleNameAndVersion = undefined
-    }
-    return {classLoader, moduleNameAndVersion}
+  const slashIndex = beforeParen.indexOf('/')
+  if (slashIndex === -1) {
+    return {tracePath: beforeParen}
   }
-  return {classLoader: undefined, moduleNameAndVersion: undefined}
+
+  const firstSegment = beforeParen.substring(0, slashIndex)
+  const afterFirstSlash = beforeParen.substring(slashIndex + 1)
+
+  // classloader//method
+  if (afterFirstSlash.startsWith('/')) {
+    return {
+      classLoader: firstSegment,
+      tracePath: afterFirstSlash.substring(1)
+    }
+  }
+
+  const secondSlashIndex = afterFirstSlash.indexOf('/')
+  if (secondSlashIndex !== -1) {
+    const secondSegment = afterFirstSlash.substring(0, secondSlashIndex)
+    const tracePath = afterFirstSlash.substring(secondSlashIndex + 1)
+    return {
+      classLoader: firstSegment,
+      moduleNameAndVersion: secondSegment,
+      tracePath
+    }
+  }
+
+  // module/method (e.g. java.base/java.lang.Thread.getStackTrace)
+  return {
+    moduleNameAndVersion: firstSegment,
+    tracePath: afterFirstSlash
+  }
 }


### PR DESCRIPTION
## Summary
- improve java-junit source for multi-module paths, uppercase package segments, and Java 9 module-prefixed stack traces map back to tracked test files
- add parser coverage for those stack trace/path cases and a real Gradle + Spring Boot JUnit 5 regression fixture
- verify annotation generation resolves the expected file and line for the reported failure shape

Closes #678.

## Test plan
- [x] `npm test -- --runInBand __tests__/java-junit.test.ts`
- [x] `npm test -- --runInBand __tests__/java-stack-trace-element-parser.test.ts`


Made with [Cursor](https://cursor.com)