### PR TITLE
fix: escape all pipe characters in markdown table cells

### DIFF
--- a/__tests__/markdown-utils.test.ts
+++ b/__tests__/markdown-utils.test.ts
@@ -1,0 +1,26 @@
+import {Align, table, tableEscape} from '../src/utils/markdown-utils.js'
+
+// Counts the GFM cells in a table row by counting unescaped pipe delimiters.
+// A row `| a | b | c |` has 4 unescaped pipes and therefore 3 cells.
+function cellCount(row: string): number {
+  const pipes = row.match(/(?<!\\)\|/g)?.length ?? 0
+  return pipes - 1
+}
+
+describe('markdown-utils table escaping', () => {
+  it('escapes every pipe in a cell, not just the first one', () => {
+    // Test/suite names regularly contain more than one pipe, e.g. a TypeScript
+    // union rendered in a test title.
+    expect(tableEscape("Type 'A | B | C'")).toBe("Type 'A \\| B \\| C'")
+  })
+
+  it('keeps the content row cell count aligned with the header when a cell contains multiple pipes', () => {
+    const headers = ['Name', 'Passed', 'Time']
+    const align = [Align.Left, Align.Right, Align.Right]
+    const md = table(headers, align, ['a | b | c', '1', '5ms'])
+    const rows = md.split('\n')
+    const headerCells = cellCount(rows[0])
+    const contentCells = cellCount(rows[rows.length - 1])
+    expect(contentCells).toBe(headerCells)
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -56758,7 +56758,7 @@ function table(headers, align, ...rows) {
     return [headerRow, alignRow, contentRows].join('\n');
 }
 function tableEscape(content) {
-    return content.toString().replace('|', '\\|');
+    return content.toString().replace(/\|/g, '\\|');
 }
 function fixEol(text) {
     return text?.replace(/\r/g, '') ?? '';

--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -24,7 +24,7 @@ export function table(headers: ToString[], align: ToString[], ...rows: ToString[
 }
 
 export function tableEscape(content: ToString): string {
-  return content.toString().replace('|', '\\|')
+  return content.toString().replace(/\|/g, '\\|')
 }
 
 export function fixEol(text?: string): string {


### PR DESCRIPTION
`tableEscape` only escapes the first pipe in a cell:

```ts
return content.toString().replace('|', '\\|')
```

`String.prototype.replace` with a string pattern replaces a single match, so a cell value that contains more than one `|` keeps every pipe after the first one unescaped. Those raw pipes are then read as extra column separators, so the row ends up with more cells than the header and the GFM table breaks (cells shift right and content is lost).

This is reachable from real input. Suite and test names flow straight into the table: `get-report.ts` builds the suites table from `s.name`, and for skipped-link rows the name is passed through verbatim. Names with two or more pipes are common in practice, for example a parameterized name or a TypeScript union shown in a title like `Type 'A | B | C'`.

The fix makes the replacement global, matching how the rest of this file already does global replaces (`fixEol`, `encodeImgShieldsURIComponent`):

```ts
return content.toString().replace(/\|/g, '\\|')
```

I added a unit test for a multi-pipe cell: it checks that every pipe is escaped and that the rendered content row keeps the same cell count as the header. Without the fix the row has 4 cells against a 3-column header; with it they match. The full suite stays green with no snapshot changes, and `dist/` is rebuilt.
