### PR TITLE
Add link on badge when using GH Action Summary

### DIFF
--- a/.github/workflows/test-all-reports.yml
+++ b/.github/workflows/test-all-reports.yml
@@ -69,8 +69,80 @@ jobs:
     - uses: actions/checkout@v7
 
     - uses: ./
+      id: report
       with:
         name: ${{ matrix.reporter }} report
         path: ${{ matrix.path }}
         reporter: ${{ matrix.reporter }}
         fail-on-error: false
+
+    - name: Generate a second report for anchor validation
+      if: ${{ matrix.reporter == 'jest-junit' }}
+      id: second_report
+      uses: ./
+      with:
+        name: jest-junit alternate report
+        path: ${{ matrix.path }}
+        reporter: ${{ matrix.reporter }}
+        fail-on-error: false
+
+    - name: Verify report names produce unique anchors
+      if: ${{ matrix.reporter == 'jest-junit' }}
+      env:
+        FIRST_REPORT_NAME: ${{ matrix.reporter }} report
+        FIRST_SLUG_PREFIX: ${{ steps.report.outputs.slug_prefix }}
+        FIRST_SUMMARY_FILE: ${{ steps.report.outputs.summary_file }}
+        SECOND_REPORT_NAME: jest-junit alternate report
+        SECOND_SLUG_PREFIX: ${{ steps.second_report.outputs.slug_prefix }}
+        SECOND_SUMMARY_FILE: ${{ steps.second_report.outputs.summary_file }}
+      run: |
+        node --input-type=module <<'NODE'
+        import {readFileSync} from 'node:fs'
+
+        function anchorId(prefix, reportName, anchor) {
+          const slug = `${prefix}${reportName}-${anchor}`
+            .trim()
+            .replace(/_/g, '')
+            .replace(/[./\\]/g, '-')
+            .replace(/[^\w-]/g, '')
+            .toLowerCase()
+          return `user-content-${slug}`
+        }
+
+        const reports = [
+          {
+            name: process.env.FIRST_REPORT_NAME,
+            prefix: process.env.FIRST_SLUG_PREFIX,
+            summaryFile: process.env.FIRST_SUMMARY_FILE
+          },
+          {
+            name: process.env.SECOND_REPORT_NAME,
+            prefix: process.env.SECOND_SLUG_PREFIX,
+            summaryFile: process.env.SECOND_SUMMARY_FILE
+          }
+        ]
+
+        const reportAnchorIds = reports.map(report => anchorId(report.prefix, report.name, 'test-report'))
+        if (new Set(reportAnchorIds).size !== reports.length) {
+          throw new Error(`Report anchors are not unique: ${reportAnchorIds.join(', ')}`)
+        }
+
+        for (const [index, report] of reports.entries()) {
+          const summary = readFileSync(report.summaryFile, 'utf8')
+          const reportAnchorId = reportAnchorIds[index]
+          const runAnchorId = anchorId(report.prefix, report.name, 'r0')
+          const suiteAnchorId = anchorId(report.prefix, report.name, 'r0s0')
+          const expectedContent = [
+            `](#${reportAnchorId})`,
+            `<a name="${reportAnchorId}"></a>`,
+            `href="#${runAnchorId}"`,
+            `href="#${suiteAnchorId}"`
+          ]
+
+          for (const expected of expectedContent) {
+            if (!summary.includes(expected)) {
+              throw new Error(`Summary ${report.summaryFile} does not contain ${expected}`)
+            }
+          }
+        }
+        NODE

--- a/__tests__/__outputs__/dart-json.md
+++ b/__tests__/__outputs__/dart-json.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dart-json.json](#user-content-r0)|1 ✅|4 ❌|1 ⚪|4s|

--- a/__tests__/__outputs__/dart-json.md
+++ b/__tests__/__outputs__/dart-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dart-json.json](#user-content-r0)|1 ✅|4 ❌|1 ⚪|4s|

--- a/__tests__/__outputs__/dotnet-nunit.md
+++ b/__tests__/__outputs__/dotnet-nunit.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dotnet-nunit.xml](#user-content-r0)|3 ✅|5 ❌|1 ⚪|230ms|

--- a/__tests__/__outputs__/dotnet-nunit.md
+++ b/__tests__/__outputs__/dotnet-nunit.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-3%20passed%2C%205%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dotnet-nunit.xml](#user-content-r0)|3 ✅|5 ❌|1 ⚪|230ms|

--- a/__tests__/__outputs__/dotnet-trx-only-failed.md
+++ b/__tests__/__outputs__/dotnet-trx-only-failed.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dotnet-trx.trx](#user-content-r0)|5 ✅|5 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/dotnet-trx.md
+++ b/__tests__/__outputs__/dotnet-trx.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dotnet-trx.trx](#user-content-r0)|5 ✅|5 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/dotnet-trx.md
+++ b/__tests__/__outputs__/dotnet-trx.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%205%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dotnet-trx.trx](#user-content-r0)|5 ✅|5 ❌|1 ⚪|1s|

--- a/__tests__/__outputs__/dotnet-xunitv3.md
+++ b/__tests__/__outputs__/dotnet-xunitv3.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%203%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%203%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/dotnet-xunitv3.trx](#user-content-r0)|1 ✅|3 ❌||267ms|

--- a/__tests__/__outputs__/fluent-validation-test-results.md
+++ b/__tests__/__outputs__/fluent-validation-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/FluentValidation.Tests.trx](#user-content-r0)|803 ✅||1 ⚪|4s|

--- a/__tests__/__outputs__/fluent-validation-test-results.md
+++ b/__tests__/__outputs__/fluent-validation-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-803%20passed%2C%201%20skipped-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/FluentValidation.Tests.trx](#user-content-r0)|803 ✅||1 ⚪|4s|

--- a/__tests__/__outputs__/golang-json.md
+++ b/__tests__/__outputs__/golang-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%206%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%206%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/golang-json.json](#user-content-r0)|5 ✅|6 ❌|1 ⚪|6s|

--- a/__tests__/__outputs__/jest-junit-eslint.md
+++ b/__tests__/__outputs__/jest-junit-eslint.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/jest-junit-eslint.xml](#user-content-r0)|1 ✅|||0ms|

--- a/__tests__/__outputs__/jest-junit-eslint.md
+++ b/__tests__/__outputs__/jest-junit-eslint.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/jest-junit-eslint.xml](#user-content-r0)|1 ✅|||0ms|

--- a/__tests__/__outputs__/jest-junit.md
+++ b/__tests__/__outputs__/jest-junit.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/jest-junit.xml](#user-content-r0)|1 ✅|4 ❌|1 ⚪|191ms|

--- a/__tests__/__outputs__/jest-junit.md
+++ b/__tests__/__outputs__/jest-junit.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/jest-junit.xml](#user-content-r0)|1 ✅|4 ❌|1 ⚪|191ms|

--- a/__tests__/__outputs__/jest-react-component-test-results.md
+++ b/__tests__/__outputs__/jest-react-component-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/jest/jest-react-component-test-results.xml](#user-content-r0)|1 ✅|||1000ms|

--- a/__tests__/__outputs__/jest-react-component-test-results.md
+++ b/__tests__/__outputs__/jest-react-component-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/jest/jest-react-component-test-results.xml](#user-content-r0)|1 ✅|||1000ms|

--- a/__tests__/__outputs__/jest-test-errors-results.md
+++ b/__tests__/__outputs__/jest-test-errors-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-2%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-2%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/test-errors/jest/jest-test-results.xml](#user-content-r0)||2 ❌||646ms|

--- a/__tests__/__outputs__/jest-test-results.md
+++ b/__tests__/__outputs__/jest-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/jest/jest-test-results.xml](#user-content-r0)|4207 ✅|2 ❌|30 ⚪|166s|

--- a/__tests__/__outputs__/jest-test-results.md
+++ b/__tests__/__outputs__/jest-test-results.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-4207%20passed%2C%202%20failed%2C%2030%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/jest/jest-test-results.xml](#user-content-r0)|4207 ✅|2 ❌|30 ⚪|166s|

--- a/__tests__/__outputs__/junit-basic.md
+++ b/__tests__/__outputs__/junit-basic.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%201%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%201%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/java/junit4-basic.xml](#user-content-r0)|5 ✅|1 ❌||16s|

--- a/__tests__/__outputs__/junit-complete.md
+++ b/__tests__/__outputs__/junit-complete.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/java/junit4-complete.xml](#user-content-r0)|5 ✅|2 ❌|1 ⚪|16s|

--- a/__tests__/__outputs__/junit-with-message.md
+++ b/__tests__/__outputs__/junit-with-message.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/junit-with-message.xml](#user-content-r0)||1 ❌||1ms|

--- a/__tests__/__outputs__/mocha-json.md
+++ b/__tests__/__outputs__/mocha-json.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/mocha-json.json](#user-content-r0)|1 ✅|4 ❌|1 ⚪|12ms|

--- a/__tests__/__outputs__/mocha-json.md
+++ b/__tests__/__outputs__/mocha-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%204%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/mocha-json.json](#user-content-r0)|1 ✅|4 ❌|1 ⚪|12ms|

--- a/__tests__/__outputs__/mocha-test-results.md
+++ b/__tests__/__outputs__/mocha-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/mocha/mocha-test-results.json](#user-content-r0)|833 ✅||6 ⚪|6s|

--- a/__tests__/__outputs__/mocha-test-results.md
+++ b/__tests__/__outputs__/mocha-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-833%20passed%2C%206%20skipped-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/mocha/mocha-test-results.json](#user-content-r0)|833 ✅||6 ⚪|6s|

--- a/__tests__/__outputs__/phpunit-junit-basic-results.md
+++ b/__tests__/__outputs__/phpunit-junit-basic-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-8%20passed%2C%201%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-8%20passed%2C%201%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/phpunit/junit-basic.xml](#user-content-r0)|8 ✅|1 ❌||16s|

--- a/__tests__/__outputs__/phpunit-phpcheckstyle-results.md
+++ b/__tests__/__outputs__/phpunit-phpcheckstyle-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-28%20passed%2C%202%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-28%20passed%2C%202%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/phpunit/phpcheckstyle-phpunit.xml](#user-content-r0)|28 ✅|2 ❌||41ms|

--- a/__tests__/__outputs__/phpunit-test-results.md
+++ b/__tests__/__outputs__/phpunit-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-10%20passed%2C%202%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-10%20passed%2C%202%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/phpunit/phpunit.xml](#user-content-r0)|10 ✅|2 ❌||148ms|

--- a/__tests__/__outputs__/provider-test-results.md
+++ b/__tests__/__outputs__/provider-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/flutter/provider-test-results.json](#user-content-r0)|268 ✅|1 ❌||0ms|

--- a/__tests__/__outputs__/provider-test-results.md
+++ b/__tests__/__outputs__/provider-test-results.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-268%20passed%2C%201%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/flutter/provider-test-results.json](#user-content-r0)|268 ✅|1 ❌||0ms|

--- a/__tests__/__outputs__/pulsar-test-results-no-merge.md
+++ b/__tests__/__outputs__/pulsar-test-results-no-merge.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml](#user-content-r0)||1 ❌|1 ⚪|116ms|

--- a/__tests__/__outputs__/pulsar-test-results-no-merge.md
+++ b/__tests__/__outputs__/pulsar-test-results-no-merge.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/java/TEST-org.apache.pulsar.AddMissingPatchVersionTest.xml](#user-content-r0)||1 ❌|1 ⚪|116ms|

--- a/__tests__/__outputs__/pulsar-test-results.md
+++ b/__tests__/__outputs__/pulsar-test-results.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/java/pulsar-test-report.xml](#user-content-r0)|793 ✅|1 ❌|14 ⚪|2127s|

--- a/__tests__/__outputs__/pulsar-test-results.md
+++ b/__tests__/__outputs__/pulsar-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-793%20passed%2C%201%20failed%2C%2014%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/java/pulsar-test-report.xml](#user-content-r0)|793 ✅|1 ❌|14 ⚪|2127s|

--- a/__tests__/__outputs__/python-xunit-pytest.md
+++ b/__tests__/__outputs__/python-xunit-pytest.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-6%20passed%2C%202%20failed%2C%202%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-6%20passed%2C%202%20failed%2C%202%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/python-xunit-pytest.xml](#user-content-r0)|6 ✅|2 ❌|2 ⚪|19ms|

--- a/__tests__/__outputs__/python-xunit-unittest.md
+++ b/__tests__/__outputs__/python-xunit-unittest.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-4%20passed%2C%202%20failed%2C%202%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-4%20passed%2C%202%20failed%2C%202%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/python-xunit-unittest.xml](#user-content-r0)|4 ✅|2 ❌|2 ⚪|1ms|

--- a/__tests__/__outputs__/rspec-json.md
+++ b/__tests__/__outputs__/rspec-json.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/rspec-json.json](#user-content-r0)|1 ✅|1 ❌|1 ⚪|0ms|

--- a/__tests__/__outputs__/rspec-json.md
+++ b/__tests__/__outputs__/rspec-json.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-1%20passed%2C%201%20failed%2C%201%20skipped-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/rspec-json.json](#user-content-r0)|1 ✅|1 ❌|1 ⚪|0ms|

--- a/__tests__/__outputs__/silent-notes-test-results.md
+++ b/__tests__/__outputs__/silent-notes-test-results.md
@@ -1,7 +1,7 @@
-[![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)](#test-report)
+[![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
-# <a name="test-report"></a> Tests report
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/SilentNotes.trx](#user-content-r0)|67 ✅||12 ⚪|1s|

--- a/__tests__/__outputs__/silent-notes-test-results.md
+++ b/__tests__/__outputs__/silent-notes-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-67%20passed%2C%2012%20skipped-success)](#test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/external/SilentNotes.trx](#user-content-r0)|67 ✅||12 ⚪|1s|

--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -1,5 +1,5 @@
-[![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)](#test-report)
-# <a name="test-report"></a> Tests report
+[![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/swift-xunit.xml](#user-content-r0)|2 ✅|1 ❌||220ms|

--- a/__tests__/__outputs__/swift-xunit.md
+++ b/__tests__/__outputs__/swift-xunit.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)
+[![Tests failed](https://img.shields.io/badge/tests-2%20passed%2C%201%20failed-critical)](#test-report)
+# <a name="test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/swift-xunit.xml](#user-content-r0)|2 ✅|1 ❌||220ms|

--- a/__tests__/__outputs__/tester-bootstrap-test-results.md
+++ b/__tests__/__outputs__/tester-bootstrap-test-results.md
@@ -1,6 +1,7 @@
-![Tests passed successfully](https://img.shields.io/badge/tests-4%20passed-success)
+[![Tests passed successfully](https://img.shields.io/badge/tests-4%20passed-success)](#user-content-test-report)
 <details><summary>Expand for details</summary>
  
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/nette-tester/BootstrapFormRenderer-report.xml](#user-content-r0)|4 ✅|||300ms|

--- a/__tests__/__outputs__/tester-v1.7-test-results.md
+++ b/__tests__/__outputs__/tester-v1.7-test-results.md
@@ -1,4 +1,5 @@
-![Tests failed](https://img.shields.io/badge/tests-61%20passed%2C%201%20failed%2C%203%20skipped-critical)
+[![Tests failed](https://img.shields.io/badge/tests-61%20passed%2C%201%20failed%2C%203%20skipped-critical)](#user-content-test-report)
+# <a name="user-content-test-report"></a> Tests report
 |Report|Passed|Failed|Skipped|Time|
 |:---|---:|---:|---:|---:|
 |[fixtures/nette-tester/tester-v1.7-report.xml](#user-content-r0)|61 ✅|1 ❌|3 ⚪|2s|

--- a/__tests__/dart-json.test.ts
+++ b/__tests__/dart-json.test.ts
@@ -86,7 +86,7 @@ describe('dart-json tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -111,7 +111,7 @@ describe('dart-json tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/dotnet-nunit.test.ts
+++ b/__tests__/dotnet-nunit.test.ts
@@ -46,7 +46,7 @@ describe('dotnet-nunit tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -71,7 +71,7 @@ describe('dotnet-nunit tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/dotnet-trx.test.ts
+++ b/__tests__/dotnet-trx.test.ts
@@ -149,7 +149,7 @@ describe('dotnet-trx tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -174,7 +174,7 @@ describe('dotnet-trx tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/java-junit.test.ts
+++ b/__tests__/java-junit.test.ts
@@ -150,7 +150,7 @@ describe('java-junit tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -175,7 +175,7 @@ describe('java-junit tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/jest-junit.test.ts
+++ b/__tests__/jest-junit.test.ts
@@ -165,7 +165,7 @@ describe('jest-junit tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -190,7 +190,7 @@ describe('jest-junit tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/mocha-json.test.ts
+++ b/__tests__/mocha-json.test.ts
@@ -84,7 +84,7 @@ describe('mocha-json tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -109,7 +109,7 @@ describe('mocha-json tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/python-xunit.test.ts
+++ b/__tests__/python-xunit.test.ts
@@ -43,7 +43,7 @@ describe('python-xunit unittest report', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -59,7 +59,7 @@ describe('python-xunit unittest report', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/report/get-report.test.ts
+++ b/__tests__/report/get-report.test.ts
@@ -10,7 +10,7 @@ describe('getBadge', () => {
       }
       const badge = getBadge(5, 0, 1, options)
       expect(badge).toBe(
-        '![Tests passed successfully](https://img.shields.io/badge/tests-5%20passed%2C%201%20skipped-success)'
+        '[![Tests passed successfully](https://img.shields.io/badge/tests-5%20passed%2C%201%20skipped-success)](#user-content-test-report)'
       )
     })
 
@@ -21,7 +21,9 @@ describe('getBadge', () => {
       }
       const badge = getBadge(3, 0, 0, options)
       // The hyphen in the badge title should be encoded as --
-      expect(badge).toBe('![Tests passed successfully](https://img.shields.io/badge/unit--tests-3%20passed-success)')
+      expect(badge).toBe(
+        '[![Tests passed successfully](https://img.shields.io/badge/unit--tests-3%20passed-success)](#user-content-test-report)'
+      )
     })
 
     it('handles badge title with multiple hyphens', () => {
@@ -32,7 +34,7 @@ describe('getBadge', () => {
       const badge = getBadge(10, 0, 0, options)
       // All hyphens in the title should be encoded as --
       expect(badge).toBe(
-        '![Tests passed successfully](https://img.shields.io/badge/integration--api--tests-10%20passed-success)'
+        '[![Tests passed successfully](https://img.shields.io/badge/integration--api--tests-10%20passed-success)](#user-content-test-report)'
       )
     })
 
@@ -44,7 +46,7 @@ describe('getBadge', () => {
       const badge = getBadge(10, 0, 0, options)
       // All underscores in the title should be encoded as __
       expect(badge).toBe(
-        '![Tests passed successfully](https://img.shields.io/badge/my__integration__test-10%20passed-success)'
+        '[![Tests passed successfully](https://img.shields.io/badge/my__integration__test-10%20passed-success)](#user-content-test-report)'
       )
     })
 
@@ -56,7 +58,7 @@ describe('getBadge', () => {
       const badge = getBadge(1, 0, 0, options)
       // The hyphen in "12.0-ubi" should be encoded as --
       expect(badge).toBe(
-        '![Tests passed successfully](https://img.shields.io/badge/MariaDb%2012.0--ubi%20database%20tests-1%20passed-success)'
+        '[![Tests passed successfully](https://img.shields.io/badge/MariaDb%2012.0--ubi%20database%20tests-1%20passed-success)](#user-content-test-report)'
       )
     })
 
@@ -67,7 +69,7 @@ describe('getBadge', () => {
       }
       const badge = getBadge(4, 1, 0, options)
       expect(badge).toBe(
-        '![Tests failed](https://img.shields.io/badge/v1.2.3--beta--test-4%20passed%2C%201%20failed-critical)'
+        '[![Tests failed](https://img.shields.io/badge/v1.2.3--beta--test-4%20passed%2C%201%20failed-critical)](#user-content-test-report)'
       )
     })
 
@@ -79,7 +81,7 @@ describe('getBadge', () => {
       const badge = getBadge(2, 3, 1, options)
       // The URI should have literal hyphens separating title-message-color
       expect(badge).toBe(
-        '![Tests failed](https://img.shields.io/badge/test--suite-2%20passed%2C%203%20failed%2C%201%20skipped-critical)'
+        '[![Tests failed](https://img.shields.io/badge/test--suite-2%20passed%2C%203%20failed%2C%201%20skipped-critical)](#user-content-test-report)'
       )
     })
   })
@@ -108,27 +110,33 @@ describe('getBadge', () => {
     it('includes only passed count when no failures or skips', () => {
       const options: ReportOptions = {...DEFAULT_OPTIONS}
       const badge = getBadge(5, 0, 0, options)
-      expect(badge).toBe('![Tests passed successfully](https://img.shields.io/badge/tests-5%20passed-success)')
+      expect(badge).toBe(
+        '[![Tests passed successfully](https://img.shields.io/badge/tests-5%20passed-success)](#user-content-test-report)'
+      )
     })
 
     it('includes passed and failed counts', () => {
       const options: ReportOptions = {...DEFAULT_OPTIONS}
       const badge = getBadge(5, 2, 0, options)
-      expect(badge).toBe('![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed-critical)')
+      expect(badge).toBe(
+        '[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed-critical)](#user-content-test-report)'
+      )
     })
 
     it('includes passed, failed and skipped counts', () => {
       const options: ReportOptions = {...DEFAULT_OPTIONS}
       const badge = getBadge(5, 2, 1, options)
       expect(badge).toBe(
-        '![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed%2C%201%20skipped-critical)'
+        '[![Tests failed](https://img.shields.io/badge/tests-5%20passed%2C%202%20failed%2C%201%20skipped-critical)](#user-content-test-report)'
       )
     })
 
     it('uses "none" message when no tests', () => {
       const options: ReportOptions = {...DEFAULT_OPTIONS}
       const badge = getBadge(0, 0, 0, options)
-      expect(badge).toBe('![Tests passed successfully](https://img.shields.io/badge/tests-none-yellow)')
+      expect(badge).toBe(
+        '[![Tests passed successfully](https://img.shields.io/badge/tests-none-yellow)](#user-content-test-report)'
+      )
     })
   })
 })
@@ -156,6 +164,31 @@ describe('getReport', () => {
     const suite = new TestSuiteResult('test-suite', [group])
     return new TestRunResult(path, [suite])
   }
+
+  describe('anchor names', () => {
+    it('uses the report name to keep anchors unique within an action run', () => {
+      const results = [createTestResult('result.xml', 1, 0, 0)]
+      const commonOptions: ReportOptions = {
+        ...DEFAULT_OPTIONS,
+        slugPrefix: 'tr-run-',
+        collapsed: 'never'
+      }
+
+      const unitReport = getReport(results, {...commonOptions, name: 'Unit tests'})
+      const integrationReport = getReport(results, {...commonOptions, name: 'Integration tests'})
+
+      expect(unitReport).toContain(
+        '](#user-content-tr-run-Unittests-test-report)\n# <a name="user-content-tr-run-Unittests-test-report"></a> Tests report'
+      )
+      expect(unitReport).toContain('href="#user-content-tr-run-Unittests-r0"')
+      expect(unitReport).toContain('href="#user-content-tr-run-Unittests-r0s0"')
+
+      expect(integrationReport).toContain(
+        '](#user-content-tr-run-Integrationtests-test-report)\n# <a name="user-content-tr-run-Integrationtests-test-report"></a> Tests report'
+      )
+      expect(integrationReport).not.toContain('user-content-tr-run-Unittests-')
+    })
+  })
 
   describe('list-files parameter', () => {
     const results = [

--- a/__tests__/report/get-report.test.ts
+++ b/__tests__/report/get-report.test.ts
@@ -178,15 +178,15 @@ describe('getReport', () => {
       const integrationReport = getReport(results, {...commonOptions, name: 'Integration tests'})
 
       expect(unitReport).toContain(
-        '](#user-content-tr-run-Unittests-test-report)\n# <a name="user-content-tr-run-Unittests-test-report"></a> Tests report'
+        '](#user-content-tr-run-unittests-test-report)\n# <a name="user-content-tr-run-unittests-test-report"></a> Tests report'
       )
-      expect(unitReport).toContain('href="#user-content-tr-run-Unittests-r0"')
-      expect(unitReport).toContain('href="#user-content-tr-run-Unittests-r0s0"')
+      expect(unitReport).toContain('href="#user-content-tr-run-unittests-r0"')
+      expect(unitReport).toContain('href="#user-content-tr-run-unittests-r0s0"')
 
       expect(integrationReport).toContain(
-        '](#user-content-tr-run-Integrationtests-test-report)\n# <a name="user-content-tr-run-Integrationtests-test-report"></a> Tests report'
+        '](#user-content-tr-run-integrationtests-test-report)\n# <a name="user-content-tr-run-integrationtests-test-report"></a> Tests report'
       )
-      expect(integrationReport).not.toContain('user-content-tr-run-Unittests-')
+      expect(integrationReport).not.toContain('user-content-tr-run-unittests-')
     })
   })
 

--- a/__tests__/rspec-json.test.ts
+++ b/__tests__/rspec-json.test.ts
@@ -62,7 +62,7 @@ describe('rspec-json tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -87,7 +87,7 @@ describe('rspec-json tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/swift-xunit.test.ts
+++ b/__tests__/swift-xunit.test.ts
@@ -47,7 +47,7 @@ describe('swift-xunit tests', () => {
     const result = await parser.parse(filePath, fileContent)
     const report = getReport([result])
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it.each([
@@ -72,7 +72,7 @@ describe('swift-xunit tests', () => {
       reportTitle
     })
     // Report should have the badge as the first line
-    expect(report).toMatch(/^!\[Tests failed]/)
+    expect(report).toMatch(/^\[!\[Tests failed]/)
   })
 
   it('report includes a custom report title', async () => {

--- a/__tests__/utils/slugger.test.ts
+++ b/__tests__/utils/slugger.test.ts
@@ -25,4 +25,16 @@ describe('slugger', () => {
       link: '#user-content-my-customprefix-r0'
     })
   })
+
+  it('normalizes anchor IDs and links to lowercase', () => {
+    const result = slug('Report-A', {
+      ...DEFAULT_OPTIONS,
+      slugPrefix: 'TR-AbCd-'
+    })
+
+    expect(result).toEqual({
+      id: 'user-content-tr-abcd-report-a',
+      link: '#user-content-tr-abcd-report-a'
+    })
+  })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -57652,7 +57652,8 @@ function slug(name, options) {
         .trim()
         .replace(/_/g, '')
         .replace(/[./\\]/g, '-')
-        .replace(/[^\w-]/g, '');
+        .replace(/[^\w-]/g, '')
+        .toLowerCase();
     const id = `user-content-${slugId}`;
     // When using the Action Summary for display, links must include the "user-content-" prefix.
     const link = options.useActionsSummary ? `#${id}` : `#${slugId}`;
@@ -57668,6 +57669,7 @@ function slug(name, options) {
 const MAX_REPORT_LENGTH = 65535;
 const MAX_ACTIONS_SUMMARY_LENGTH = 1048576;
 const DEFAULT_OPTIONS = {
+    name: '',
     listSuites: 'all',
     listTests: 'all',
     slugPrefix: '',
@@ -57781,7 +57783,8 @@ function getBadge(passed, failed, skipped, options) {
     const encodedBadgeTitle = encodeImgShieldsURIComponent(options.badgeTitle);
     const encodedMessage = encodeImgShieldsURIComponent(message);
     const encodedColor = encodeImgShieldsURIComponent(color);
-    return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](#user-content-test-report)`;
+    const reportSlug = makeReportSlug(options);
+    return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](${reportSlug.link})`;
 }
 function getTestRunsReport(testRuns, options) {
     const sections = [];
@@ -57792,7 +57795,8 @@ function getTestRunsReport(testRuns, options) {
         sections.push(`<details><summary>Expand for details</summary>`);
         sections.push(` `);
     }
-    sections.push('# <a name="user-content-test-report"></a> Tests report');
+    const reportSlug = makeReportSlug(options);
+    sections.push(`# <a name="${reportSlug.id}"></a> Tests report`);
     // Filter test runs based on list-files option
     const filteredTestRuns = options.listFiles === 'failed'
         ? testRuns.filter(tr => tr.result === 'failed')
@@ -57902,11 +57906,18 @@ function getTestsReport(ts, runIndex, suiteIndex, options) {
 }
 function makeRunSlug(runIndex, options) {
     // use prefix to avoid slug conflicts after escaping the paths
-    return slug(`r${runIndex}`, options);
+    return makeNamedSlug(`r${runIndex}`, options);
 }
 function makeSuiteSlug(runIndex, suiteIndex, options) {
     // use prefix to avoid slug conflicts after escaping the paths
-    return slug(`r${runIndex}s${suiteIndex}`, options);
+    return makeNamedSlug(`r${runIndex}s${suiteIndex}`, options);
+}
+function makeReportSlug(options) {
+    return makeNamedSlug('test-report', options);
+}
+function makeNamedSlug(anchor, options) {
+    const namePrefix = options.name ? `${options.name}-` : '';
+    return slug(`${namePrefix}${anchor}`, options);
 }
 function getResultIcon(result) {
     switch (result) {
@@ -59684,7 +59695,7 @@ class TestReporter {
     workDirInput = getInput('working-directory', { required: false });
     onlySummary = getInput('only-summary', { required: false }) === 'true';
     useActionsSummary = getInput('use-actions-summary', { required: false }) === 'true';
-    slugPrefix = `tr-${(0,external_node_crypto_.randomBytes)(4).toString('base64url')}-`;
+    slugPrefix = `tr-${(0,external_node_crypto_.randomBytes)(4).toString('hex')}-`;
     badgeTitle = getInput('badge-title', { required: false });
     reportTitle = getInput('report-title', { required: false });
     collapsed = getInput('collapsed', { required: false });
@@ -59797,6 +59808,7 @@ class TestReporter {
         let baseUrl = '';
         if (this.useActionsSummary) {
             const summary = getReport(results, {
+                name,
                 listSuites,
                 listTests,
                 slugPrefix,
@@ -59828,6 +59840,7 @@ class TestReporter {
             info('Creating report summary');
             baseUrl = createResp.data.html_url;
             const summary = getReport(results, {
+                name,
                 listSuites,
                 listTests,
                 slugPrefix,

--- a/dist/index.js
+++ b/dist/index.js
@@ -57781,7 +57781,7 @@ function getBadge(passed, failed, skipped, options) {
     const encodedBadgeTitle = encodeImgShieldsURIComponent(options.badgeTitle);
     const encodedMessage = encodeImgShieldsURIComponent(message);
     const encodedColor = encodeImgShieldsURIComponent(color);
-    return `![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})`;
+    return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](#user-content-test-report)`;
 }
 function getTestRunsReport(testRuns, options) {
     const sections = [];
@@ -57792,6 +57792,7 @@ function getTestRunsReport(testRuns, options) {
         sections.push(`<details><summary>Expand for details</summary>`);
         sections.push(` `);
     }
+    sections.push('# <a name="user-content-test-report"></a> Tests report');
     // Filter test runs based on list-files option
     const filteredTestRuns = options.listFiles === 'failed'
         ? testRuns.filter(tr => tr.result === 'failed')

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,6 +208,7 @@ class TestReporter {
       const summary = getReport(
         results,
         {
+          name,
           listSuites,
           listTests,
           slugPrefix,
@@ -242,6 +243,7 @@ class TestReporter {
       core.info('Creating report summary')
       baseUrl = createResp.data.html_url as string
       const summary = getReport(results, {
+        name,
         listSuites,
         listTests,
         slugPrefix,

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ class TestReporter {
   readonly workDirInput = core.getInput('working-directory', {required: false})
   readonly onlySummary = core.getInput('only-summary', {required: false}) === 'true'
   readonly useActionsSummary = core.getInput('use-actions-summary', {required: false}) === 'true'
-  readonly slugPrefix = `tr-${randomBytes(4).toString('base64url')}-`
+  readonly slugPrefix = `tr-${randomBytes(4).toString('hex')}-`
   readonly badgeTitle = core.getInput('badge-title', {required: false})
   readonly reportTitle = core.getInput('report-title', {required: false})
   readonly collapsed = core.getInput('collapsed', {required: false}) as 'auto' | 'always' | 'never'

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -9,6 +9,7 @@ const MAX_REPORT_LENGTH = 65535
 const MAX_ACTIONS_SUMMARY_LENGTH = 1048576
 
 export interface ReportOptions {
+  name: string
   listSuites: 'all' | 'failed' | 'none'
   listTests: 'all' | 'failed' | 'none'
   slugPrefix: string
@@ -22,6 +23,7 @@ export interface ReportOptions {
 }
 
 export const DEFAULT_OPTIONS: ReportOptions = {
+  name: '',
   listSuites: 'all',
   listTests: 'all',
   slugPrefix: '',
@@ -160,7 +162,8 @@ export function getBadge(passed: number, failed: number, skipped: number, option
   const encodedBadgeTitle = encodeImgShieldsURIComponent(options.badgeTitle)
   const encodedMessage = encodeImgShieldsURIComponent(message)
   const encodedColor = encodeImgShieldsURIComponent(color)
-  return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](#user-content-test-report)`
+  const reportSlug = makeReportSlug(options)
+  return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](${reportSlug.link})`
 }
 
 function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): string[] {
@@ -175,7 +178,8 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
     sections.push(` `)
   }
 
-  sections.push('# <a name="user-content-test-report"></a> Tests report')
+  const reportSlug = makeReportSlug(options)
+  sections.push(`# <a name="${reportSlug.id}"></a> Tests report`)
 
   // Filter test runs based on list-files option
   const filteredTestRuns =
@@ -313,12 +317,21 @@ function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: numbe
 
 function makeRunSlug(runIndex: number, options: ReportOptions): {id: string; link: string} {
   // use prefix to avoid slug conflicts after escaping the paths
-  return slug(`r${runIndex}`, options)
+  return makeNamedSlug(`r${runIndex}`, options)
 }
 
 function makeSuiteSlug(runIndex: number, suiteIndex: number, options: ReportOptions): {id: string; link: string} {
   // use prefix to avoid slug conflicts after escaping the paths
-  return slug(`r${runIndex}s${suiteIndex}`, options)
+  return makeNamedSlug(`r${runIndex}s${suiteIndex}`, options)
+}
+
+function makeReportSlug(options: ReportOptions): {id: string; link: string} {
+  return makeNamedSlug('test-report', options)
+}
+
+function makeNamedSlug(anchor: string, options: ReportOptions): {id: string; link: string} {
+  const namePrefix = options.name ? `${options.name}-` : ''
+  return slug(`${namePrefix}${anchor}`, options)
 }
 
 function getResultIcon(result: TestExecutionResult): string {

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -160,7 +160,7 @@ export function getBadge(passed: number, failed: number, skipped: number, option
   const encodedBadgeTitle = encodeImgShieldsURIComponent(options.badgeTitle)
   const encodedMessage = encodeImgShieldsURIComponent(message)
   const encodedColor = encodeImgShieldsURIComponent(color)
-  return `![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})`
+  return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](#test-report)`
 }
 
 function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): string[] {
@@ -174,6 +174,8 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
     sections.push(`<details><summary>Expand for details</summary>`)
     sections.push(` `)
   }
+
+  sections.push('# <a name="test-report"></a> Tests report')
 
   // Filter test runs based on list-files option
   const filteredTestRuns =

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -160,7 +160,7 @@ export function getBadge(passed: number, failed: number, skipped: number, option
   const encodedBadgeTitle = encodeImgShieldsURIComponent(options.badgeTitle)
   const encodedMessage = encodeImgShieldsURIComponent(message)
   const encodedColor = encodeImgShieldsURIComponent(color)
-  return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](#test-report)`
+  return `[![${hint}](https://img.shields.io/badge/${encodedBadgeTitle}-${encodedMessage}-${encodedColor})](#user-content-test-report)`
 }
 
 function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): string[] {
@@ -175,7 +175,7 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
     sections.push(` `)
   }
 
-  sections.push('# <a name="test-report"></a> Tests report')
+  sections.push('# <a name="user-content-test-report"></a> Tests report')
 
   // Filter test runs based on list-files option
   const filteredTestRuns =

--- a/src/utils/slugger.ts
+++ b/src/utils/slugger.ts
@@ -9,6 +9,7 @@ export function slug(name: string, options: ReportOptions): {id: string; link: s
     .replace(/_/g, '')
     .replace(/[./\\]/g, '-')
     .replace(/[^\w-]/g, '')
+    .toLowerCase()
 
   const id = `user-content-${slugId}`
   // When using the Action Summary for display, links must include the "user-content-" prefix.


### PR DESCRIPTION
> This is a backport of the #492 changes.
---

## Problem
As of now, clicking on the badge on GH Action Summary:
<img width="208" alt="image" src="https://github.com/dorny/test-reporter/assets/1562400/687da6c0-ad6f-4c05-b546-efcb0d845fd1">

goes to nowhere interesting (`https://camo.githubusercontent.com/xxx`).

## This PR
This (completely unsolicited) PR introduces a new feature: the badge is now in an anchor, and when clicked, this open the collapsed section and goes to the top of the tests report. At least, I can click roughly on a bigger thing than a small collapsed section 🤷‍♂️

<img width="767" alt="image" src="https://github.com/dorny/test-reporter/assets/1562400/36ee0944-f2c9-4c34-b42e-42870bda3ac1">
 
## Next
Nothing fancy, I just like it this way 🤷‍♂️ Hope you like it too! Thanks for this gh action btw.