### PR TITLE
Fix stack overflow when rendering very large reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0
 * Feature: Add `list-files` input to control test report file listing https://github.com/dorny/test-reporter/pull/773
 * Feature: Add `summary_file` output with the path to the generated summary in Markdown format https://github.com/dorny/test-reporter/pull/772
+* Fix: Render very large reports without exceeding the maximum call stack size https://github.com/dorny/test-reporter/pull/813
 
 ## 3.0.0
 * Feature: Use NodeJS 24 LTS as default runtime https://github.com/dorny/test-reporter/pull/738

--- a/__tests__/report/get-report.test.ts
+++ b/__tests__/report/get-report.test.ts
@@ -275,4 +275,63 @@ describe('getReport', () => {
       expect(report).toContain('failing-file-2.spec.ts')
     })
   })
+
+  describe('very large reports', () => {
+    // Builds a result set whose rendered form has more lines than the number of arguments a
+    // function call can take, so any spread-based array splicing overflows the stack.
+    function createLargeResults(runs: number, suitesPerRun: number, testsPerSuite: number): TestRunResult[] {
+      const results: TestRunResult[] = []
+      for (let r = 0; r < runs; r++) {
+        const suites: TestSuiteResult[] = []
+        for (let s = 0; s < suitesPerRun; s++) {
+          const tests: TestCaseResult[] = []
+          for (let t = 0; t < testsPerSuite; t++) {
+            tests.push(new TestCaseResult(`test-${t}`, 'success', 1))
+          }
+          suites.push(new TestSuiteResult(`suite-${s}`, [new TestGroupResult('group', tests)], 1))
+        }
+        results.push(new TestRunResult(`run-${r}.xml`, suites, 1))
+      }
+      return results
+    }
+
+    it('renders a report with more lines than the maximum argument count', () => {
+      // 250k tests across 10k suites renders ~280k lines - well past the ~125k argument limit.
+      const results = createLargeResults(100, 100, 25)
+
+      expect(() => getReport(results, DEFAULT_OPTIONS)).not.toThrow()
+    })
+
+    it('keeps a report of that size within the summary limit', () => {
+      const results = createLargeResults(100, 100, 25)
+
+      const report = getReport(results, DEFAULT_OPTIONS)
+
+      expect(Buffer.byteLength(report, 'utf8')).toBeLessThanOrEqual(1048576)
+      expect(report).toContain('|Report|Passed|Failed|Skipped|Time|')
+    })
+
+    it('trims a report of that size when it still does not fit', () => {
+      const results = createLargeResults(100, 100, 25)
+
+      // The lower check-run limit, which even the suite tables alone exceed.
+      const report = getReport(results, {...DEFAULT_OPTIONS, useActionsSummary: false})
+
+      expect(report).toContain('has been trimmed')
+      expect(Buffer.byteLength(report, 'utf8')).toBeLessThanOrEqual(65535)
+    })
+
+    it('renders every suite of a large report when it fits', () => {
+      // Small enough to survive spread-based splicing, so this passes with or without the fix -
+      // it guards against the fix dropping or reordering content.
+      const results = createLargeResults(2, 3, 2)
+
+      const report = getReport(results, DEFAULT_OPTIONS)
+
+      expect(report).toContain('run-0.xml')
+      expect(report).toContain('run-1.xml')
+      expect(report).toContain('suite-2')
+      expect(report.indexOf('run-0.xml')).toBeLessThan(report.indexOf('run-1.xml'))
+    })
+  })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -57463,6 +57463,11 @@ function markdown_utils_link(title, address) {
     return `[${title}](${address})`;
 }
 function table(headers, align, ...rows) {
+    return tableFromRows(headers, align, rows);
+}
+// Takes the rows as an array rather than as rest arguments. A table with more rows than the maximum
+// argument count cannot be built with `table`, because spreading them makes each row an argument.
+function tableFromRows(headers, align, rows) {
     const headerRow = `|${headers.map(tableEscape).join('|')}|`;
     const alignRow = `|${align.join('|')}|`;
     const contentRows = rows.map(row => `|${row.map(tableEscape).join('|')}|`).join('\n');
@@ -57749,8 +57754,18 @@ function renderReport(results, options, shortSummary) {
     const badge = getReportBadge(results, options);
     sections.push(badge);
     const runs = getTestRunsReport(results, options);
-    sections.push(...runs);
+    pushAll(sections, runs);
     return sections;
+}
+// Appends every item of `items` to `target`.
+//
+// This is `target.push(...items)` without the argument-count limit: spreading makes each item an
+// argument, so a large enough report - tens of thousands of tests - overflows the stack before it
+// can be rendered, let alone trimmed to fit.
+function pushAll(target, items) {
+    for (const item of items) {
+        target.push(item);
+    }
 }
 function getReportBadge(results, options) {
     const passed = results.reduce((sum, tr) => sum + tr.passed, 0);
@@ -57812,12 +57827,12 @@ function getTestRunsReport(testRuns, options) {
         return [nameLink, passed, failed, skipped, time];
     });
     if (tableData.length > 0) {
-        const resultsTable = table(['Report', 'Passed', 'Failed', 'Skipped', 'Time'], [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right], ...tableData);
+        const resultsTable = tableFromRows(['Report', 'Passed', 'Failed', 'Skipped', 'Time'], [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right], tableData);
         sections.push(resultsTable);
     }
     if (options.onlySummary === false) {
         const suitesReports = filteredTestRuns.map((tr, i) => getSuitesReport(tr, i, options)).flat();
-        sections.push(...suitesReports);
+        pushAll(sections, suitesReports);
     }
     if (shouldCollapse) {
         sections.push(`</details>`);
@@ -57838,7 +57853,7 @@ function getSuitesReport(tr, runIndex, options) {
             : 'No tests found';
         sections.push(headingLine2);
         if (suites.length > 0) {
-            const suitesTable = table(['Test suite', 'Passed', 'Failed', 'Skipped', 'Time'], [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right], ...suites.map((s, suiteIndex) => {
+            const suitesTable = tableFromRows(['Test suite', 'Passed', 'Failed', 'Skipped', 'Time'], [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right], suites.map((s, suiteIndex) => {
                 const tsTime = formatTime(s.time);
                 const tsName = s.name;
                 const skipLink = options.listTests === 'none' || (options.listTests === 'failed' && s.result !== 'failed');
@@ -57855,7 +57870,7 @@ function getSuitesReport(tr, runIndex, options) {
     if (options.listTests !== 'none') {
         const tests = suites.map((ts, suiteIndex) => getTestsReport(ts, runIndex, suiteIndex, options)).flat();
         if (tests.length > 1) {
-            sections.push(...tests);
+            pushAll(sections, tests);
         }
     }
     return sections;
@@ -57891,7 +57906,7 @@ function getTestsReport(ts, runIndex, suiteIndex, options) {
                     ?.split(/\r?\n/g)
                     .map(l => '\t' + l);
                 if (lines) {
-                    sections.push(...lines);
+                    pushAll(sections, lines);
                 }
             }
         }

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import {TestExecutionResult, TestRunResult, TestSuiteResult} from '../test-results.js'
-import {Align, formatTime, Icon, link, table} from '../utils/markdown-utils.js'
+import {Align, formatTime, Icon, link, tableFromRows} from '../utils/markdown-utils.js'
 import {DEFAULT_LOCALE} from '../utils/node-utils.js'
 import {getFirstNonEmptyLine} from '../utils/parse-utils.js'
 import {slug} from '../utils/slugger.js'
@@ -125,9 +125,20 @@ function renderReport(results: TestRunResult[], options: ReportOptions, shortSum
   sections.push(badge)
 
   const runs = getTestRunsReport(results, options)
-  sections.push(...runs)
+  pushAll(sections, runs)
 
   return sections
+}
+
+// Appends every item of `items` to `target`.
+//
+// This is `target.push(...items)` without the argument-count limit: spreading makes each item an
+// argument, so a large enough report - tens of thousands of tests - overflows the stack before it
+// can be rendered, let alone trimmed to fit.
+function pushAll<T>(target: T[], items: readonly T[]): void {
+  for (const item of items) {
+    target.push(item)
+  }
 }
 
 function getReportBadge(results: TestRunResult[], options: ReportOptions): string {
@@ -198,17 +209,17 @@ function getTestRunsReport(testRuns: TestRunResult[], options: ReportOptions): s
     })
 
   if (tableData.length > 0) {
-    const resultsTable = table(
+    const resultsTable = tableFromRows(
       ['Report', 'Passed', 'Failed', 'Skipped', 'Time'],
       [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right],
-      ...tableData
+      tableData
     )
     sections.push(resultsTable)
   }
 
   if (options.onlySummary === false) {
     const suitesReports = filteredTestRuns.map((tr, i) => getSuitesReport(tr, i, options)).flat()
-    sections.push(...suitesReports)
+    pushAll(sections, suitesReports)
   }
 
   if (shouldCollapse) {
@@ -235,10 +246,10 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
     sections.push(headingLine2)
 
     if (suites.length > 0) {
-      const suitesTable = table(
+      const suitesTable = tableFromRows(
         ['Test suite', 'Passed', 'Failed', 'Skipped', 'Time'],
         [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right],
-        ...suites.map((s, suiteIndex) => {
+        suites.map((s, suiteIndex) => {
           const tsTime = formatTime(s.time)
           const tsName = s.name
           const skipLink = options.listTests === 'none' || (options.listTests === 'failed' && s.result !== 'failed')
@@ -258,7 +269,7 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
     const tests = suites.map((ts, suiteIndex) => getTestsReport(ts, runIndex, suiteIndex, options)).flat()
 
     if (tests.length > 1) {
-      sections.push(...tests)
+      pushAll(sections, tests)
     }
   }
 
@@ -299,7 +310,7 @@ function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: numbe
           ?.split(/\r?\n/g)
           .map(l => '\t' + l)
         if (lines) {
-          sections.push(...lines)
+          pushAll(sections, lines)
         }
       }
     }

--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -17,6 +17,12 @@ export function link(title: string, address: string): string {
 
 type ToString = string | number | boolean | Date
 export function table(headers: ToString[], align: ToString[], ...rows: ToString[][]): string {
+  return tableFromRows(headers, align, rows)
+}
+
+// Takes the rows as an array rather than as rest arguments. A table with more rows than the maximum
+// argument count cannot be built with `table`, because spreading them makes each row an argument.
+export function tableFromRows(headers: ToString[], align: ToString[], rows: ToString[][]): string {
   const headerRow = `|${headers.map(tableEscape).join('|')}|`
   const alignRow = `|${align.join('|')}|`
   const contentRows = rows.map(row => `|${row.map(tableEscape).join('|')}|`).join('\n')


### PR DESCRIPTION
Fixes #249.

## The problem

On a large enough test run the action fails with `RangeError: Maximum call stack size exceeded`, immediately after logging `Generating check run summary` — every test having already passed:

```
Creating check run ...
Creating report summary
##[error]RangeError: Maximum call stack size exceeded
```

`getReport` builds the summary as one flat array of lines and splices sub-arrays in with argument spread — `sections.push(...runs)`, `sections.push(...suitesReports)`, `sections.push(...tests)`, `sections.push(...lines)`, and `table(headers, align, ...rows)` in two places. Spreading makes each line an argument, so line count becomes argument count, and past the engine's limit that throws. It's a stack overflow, not slowness.

The existing size guard can't catch it. `getReport` renders the whole report first and only then decides whether to downgrade `listTests` or trim — so a report too big to *render* never reaches the code meant to shrink it. That matches the reports in #249: the failure is driven by test volume, and it disappears when the stack is enlarged with `--stack-size`.

I hit this with 245 report files / 5,044 suites / 53,268 tests. #249 has a report at ~20,000 tests, so the practical threshold is well within what a monorepo produces.

## The change

- `pushAll(target, items)` appends in a loop instead of spreading. Replaces all four `push(...)` sites.
- `tableFromRows(headers, align, rows)` takes rows as an array. `table` keeps its variadic signature and delegates to it, so existing callers and tests are untouched.

No behavior change beyond not crashing: the 30 existing snapshots pass unmodified.

The trimming path now actually gets to run on reports this size — verified by one of the new tests.

## Tests

Three cases in `__tests__/report/get-report.test.ts`, over 100 runs × 100 suites × 25 tests (250k tests, ~280k rendered lines, ~50ms to build):

- renders without throwing — fails on `main` with the `RangeError`
- stays within the 1 MB Actions-summary limit and still contains the results table
- trims when it *still* doesn't fit (`useActionsSummary: false`, the 65,535-byte check-run limit) — this exercises `trimReport` at a size that previously crashed before reaching it

Plus a small content check (all runs present, in order) that passes with and without the fix, to catch a `pushAll` that drops or reorders lines.

Verified the three large-report tests fail on `main` and pass with the change. `npm run build`, `format-check`, `lint`, `test` (161 tests, 18 suites) and `package` all clean; `dist/` is rebuilt and committed.

One caveat on the test sizes: the argument limit depends on available stack, so these numbers are chosen with margin rather than pinned to an exact threshold. A runner with a much larger stack could render 250k lines successfully and the first test would pass for the wrong reason — it can produce a false pass, never a false failure. Making it exact would mean spawning a child process with `--stack-size`, which seemed like poor value for the suite. Happy to add it if you'd prefer.
