### PR TITLE
fix(jest-junit): handle failures with attribute-only messages

### DIFF
--- a/__tests__/jest-junit.test.ts
+++ b/__tests__/jest-junit.test.ts
@@ -12,6 +12,27 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 describe('jest-junit tests', () => {
+  it('parses failures that contain only XML attributes', async () => {
+    const parser = new JestJunitParser({
+      parseErrors: true,
+      trackedFiles: []
+    })
+    const result = await parser.parse(
+      'jest-junit.xml',
+      `<?xml version="1.0" encoding="UTF-8"?>
+      <testsuites time="0.1">
+        <testsuite name="attribute failures" tests="1" errors="0" failures="1" skipped="0" time="0.1">
+          <testcase classname="example" name="fails" time="0.1">
+            <failure message="Expected true to be false" type="AssertionError" />
+          </testcase>
+        </testsuite>
+      </testsuites>`
+    )
+
+    expect(result.failed).toBe(1)
+    expect(result.suites[0].groups[0].tests[0].error?.details).toBe('Expected true to be false')
+  })
+
   it('produces empty test run result when there are no test cases in the testsuites element', async () => {
     const fixturePath = path.join(__dirname, 'fixtures', 'empty', 'jest-junit.xml')
     const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))

--- a/src/parsers/jest-junit/jest-junit-parser.ts
+++ b/src/parsers/jest-junit/jest-junit-parser.ts
@@ -86,7 +86,7 @@ export class JestJunitParser implements TestParser {
     }
 
     const message = tc.failure ? tc.failure[0] : tc.error ? tc.error[0] : 'unknown failure'
-    const details = typeof message === 'string' ? message : message['_']
+    const details = typeof message === 'string' ? message : (message._ ?? message.$?.message ?? '')
     let path
     let line
 

--- a/src/parsers/jest-junit/jest-junit-types.ts
+++ b/src/parsers/jest-junit/jest-junit-types.ts
@@ -29,7 +29,17 @@ export interface TestCase {
     name: string
     time: string
   }
-  failure?: string[]
+  failure?: Failure[]
   skipped?: string[]
-  error?: string[]
+  error?: Failure[]
 }
+
+export type Failure =
+  | string
+  | {
+      _?: string
+      $?: {
+        message?: string
+        type?: string
+      }
+    }

--- a/src/utils/node-utils.ts
+++ b/src/utils/node-utils.ts
@@ -3,10 +3,14 @@ import {normalizeFilePath} from './path-utils.js'
 export const DEFAULT_LOCALE = 'en-US'
 
 export function getExceptionSource(
-  stackTrace: string,
+  stackTrace: unknown,
   trackedFiles: string[],
   getRelativePath: (str: string) => string
 ): {path: string; line: number} | undefined {
+  if (typeof stackTrace !== 'string') {
+    return undefined
+  }
+
   const lines = stackTrace.split(/\r?\n/)
   const re = /\((.*):(\d+):\d+\)$/
 


### PR DESCRIPTION
## Problem

For XML such as `<failure message="..." />`, `xml2js` returns an object without a text-content `_` property. The parser passed that missing value to `getExceptionSource`, which called `.split()` on `undefined` and aborted report generation.

## Solution

- Fall back to the failure's `message` attribute when text content is absent.
- Make stack-source extraction safely ignore non-string input.
- Add a regression test for the reported Jest JUnit XML shape.

## Verification

- Focused Jest JUnit suite passed — 21 tests and 6 snapshots
- `npm run build` passed
- ESLint passed for all changed files
- `git diff --check` passed

Fixes #241
