### PR TITLE
Add ignore input for test report paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ jobs:
     # All matched result files must be of the same format
     path: ''
 
+    # Comma-separated list of paths to ignore when searching for test results
+    # Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
+    ignore: ''
+
     # The fast-glob library that is internally used interprets backslashes as escape characters.
     # If enabled, all backslashes in provided path will be replaced by forward slashes and act as directory separators.
     # It might be useful when path input variable is composed dynamically from existing directory paths on Windows.
@@ -214,6 +218,22 @@ jobs:
     # Default: ${{ github.token }}
     token: ''
 ```
+
+### Ignoring paths
+
+Use `ignore` when `path` needs to search broadly, but some directories should never be scanned for test results.
+For example, monorepos can exclude dependency or generated output directories while still matching reports from multiple packages:
+
+```yaml
+- uses: dorny/test-reporter@v3
+  with:
+    name: JEST Tests
+    path: '**/test-report.junit.xml'
+    ignore: '**/node_modules/**,**/dist/**'
+    reporter: jest-junit
+```
+
+Ignore patterns use the same fast-glob syntax as `path` and are applied to both local files and files inside downloaded artifacts.
 
 ## Output parameters
 | Name       | Description              |

--- a/__tests__/input-providers/local-file-provider.test.ts
+++ b/__tests__/input-providers/local-file-provider.test.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import {LocalFileProvider} from '../../src/input-providers/local-file-provider.js'
+import {normalizeFilePath} from '../../src/utils/path-utils.js'
+
+describe('LocalFileProvider', () => {
+  const originalCwd = process.cwd()
+  let workspace: string
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'test-reporter-'))
+    process.chdir(workspace)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(workspace, {force: true, recursive: true})
+  })
+
+  function writeReport(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), {recursive: true})
+    fs.writeFileSync(filePath, content)
+  }
+
+  it('ignores matching report paths', async () => {
+    writeReport('test-report.junit.xml', 'root')
+    writeReport('packages/api/test-report.junit.xml', 'package')
+    writeReport('node_modules/root-package/test-report.junit.xml', 'root node_modules')
+    writeReport('packages/api/node_modules/nested-package/test-report.junit.xml', 'nested node_modules')
+
+    const provider = new LocalFileProvider('Tests', ['**/test-report.junit.xml'], ['**/node_modules/**'])
+    const input = await provider.load()
+
+    expect(input.Tests.map(({file}) => normalizeFilePath(file)).sort()).toEqual([
+      'packages/api/test-report.junit.xml',
+      'test-report.junit.xml'
+    ])
+    expect(input.Tests.map(({content}) => content).sort()).toEqual(['package', 'root'])
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
       Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
       All matched result files must be of same format
     required: true
+  ignore:
+    description: |
+      Comma-separated list of paths to ignore when searching for test results
+      Supports wildcards via [fast-glob](https://github.com/mrmlnc/fast-glob)
+    required: false
+    default: ''
   path-replace-backslashes:
     description: |
       The fast-glob library that is internally used interprets backslashes as escape characters.

--- a/dist/index.js
+++ b/dist/index.js
@@ -57301,17 +57301,20 @@ class ArtifactProvider {
     artifact;
     name;
     pattern;
+    ignore;
     sha;
     runId;
     token;
     artifactNameMatch;
     fileNameMatch;
+    ignoreFileNameMatch;
     getReportName;
-    constructor(octokit, artifact, name, pattern, sha, runId, token) {
+    constructor(octokit, artifact, name, pattern, ignore, sha, runId, token) {
         this.octokit = octokit;
         this.artifact = artifact;
         this.name = name;
         this.pattern = pattern;
+        this.ignore = ignore;
         this.sha = sha;
         this.runId = runId;
         this.token = token;
@@ -57338,6 +57341,7 @@ class ArtifactProvider {
             this.getReportName = () => this.name;
         }
         this.fileNameMatch = picomatch(pattern);
+        this.ignoreFileNameMatch = ignore.length === 0 ? () => false : picomatch(ignore);
     }
     async load() {
         const result = {};
@@ -57371,6 +57375,10 @@ class ArtifactProvider {
                     }
                     if (!this.fileNameMatch(file)) {
                         info(`Skipping ${file}: filename does not match pattern`);
+                        continue;
+                    }
+                    if (this.ignoreFileNameMatch(file)) {
+                        info(`Skipping ${file}: filename matches ignore pattern`);
                         continue;
                     }
                     const content = zip.readAsText(entry);
@@ -57426,14 +57434,16 @@ function fixStdOutNullTermination() {
 class LocalFileProvider {
     name;
     pattern;
-    constructor(name, pattern) {
+    ignore;
+    constructor(name, pattern, ignore = []) {
         this.name = name;
         this.pattern = pattern;
+        this.ignore = ignore;
     }
     async load() {
         const result = [];
         for (const pat of this.pattern) {
-            const paths = await out(pat, { dot: true });
+            const paths = await out(pat, { dot: true, ignore: this.ignore });
             for (const file of paths) {
                 const content = await external_fs_.promises.readFile(file, { encoding: 'utf8' });
                 result.push({ file, content });
@@ -59672,6 +59682,7 @@ class TestReporter {
     artifact = getInput('artifact', { required: false });
     name = getInput('name', { required: true });
     path = getInput('path', { required: true });
+    ignore = getInput('ignore', { required: false });
     pathReplaceBackslashes = getInput('path-replace-backslashes', { required: false }) === 'true';
     reporter = getInput('reporter', { required: true });
     listSuites = getInput('list-suites', { required: true });
@@ -59722,10 +59733,12 @@ class TestReporter {
         // Split path pattern by ',' and optionally convert all backslashes to forward slashes
         // fast-glob (micromatch) always interprets backslashes as escape characters instead of directory separators
         const pathsList = this.path.split(',');
+        const ignoreList = this.ignore.length === 0 ? [] : this.ignore.split(',');
         const pattern = this.pathReplaceBackslashes ? pathsList.map(normalizeFilePath) : pathsList;
+        const ignore = this.pathReplaceBackslashes ? ignoreList.map(normalizeFilePath) : ignoreList;
         const inputProvider = this.artifact
-            ? new ArtifactProvider(this.octokit, this.artifact, this.name, pattern, this.context.sha, this.context.runId, this.token)
-            : new LocalFileProvider(this.name, pattern);
+            ? new ArtifactProvider(this.octokit, this.artifact, this.name, pattern, ignore, this.context.sha, this.context.runId, this.token)
+            : new LocalFileProvider(this.name, pattern, ignore);
         const parseErrors = this.maxAnnotations > 0;
         const trackedFiles = parseErrors ? await inputProvider.listTrackedFiles() : [];
         const workDir = this.artifact ? undefined : normalizeDirPath(process.cwd(), true);

--- a/src/input-providers/artifact-provider.ts
+++ b/src/input-providers/artifact-provider.ts
@@ -16,6 +16,7 @@ type WorkflowRunArtifact = {
 export class ArtifactProvider implements InputProvider {
   private readonly artifactNameMatch: (name: string) => boolean
   private readonly fileNameMatch: (name: string) => boolean
+  private readonly ignoreFileNameMatch: (name: string) => boolean
   private readonly getReportName: (name: string) => string
 
   constructor(
@@ -23,6 +24,7 @@ export class ArtifactProvider implements InputProvider {
     readonly artifact: string,
     readonly name: string,
     readonly pattern: string[],
+    readonly ignore: string[],
     readonly sha: string,
     readonly runId: number,
     readonly token: string
@@ -50,6 +52,7 @@ export class ArtifactProvider implements InputProvider {
     }
 
     this.fileNameMatch = picomatch(pattern)
+    this.ignoreFileNameMatch = ignore.length === 0 ? () => false : picomatch(ignore)
   }
 
   async load(): Promise<ReportInput> {
@@ -88,6 +91,10 @@ export class ArtifactProvider implements InputProvider {
           }
           if (!this.fileNameMatch(file)) {
             core.info(`Skipping ${file}: filename does not match pattern`)
+            continue
+          }
+          if (this.ignoreFileNameMatch(file)) {
+            core.info(`Skipping ${file}: filename matches ignore pattern`)
             continue
           }
           const content = zip.readAsText(entry)

--- a/src/input-providers/local-file-provider.ts
+++ b/src/input-providers/local-file-provider.ts
@@ -6,13 +6,14 @@ import {listFiles} from '../utils/git.js'
 export class LocalFileProvider implements InputProvider {
   constructor(
     readonly name: string,
-    readonly pattern: string[]
+    readonly pattern: string[],
+    readonly ignore: string[] = []
   ) {}
 
   async load(): Promise<ReportInput> {
     const result: FileContent[] = []
     for (const pat of this.pattern) {
-      const paths = await glob(pat, {dot: true})
+      const paths = await glob(pat, {dot: true, ignore: this.ignore})
       for (const file of paths) {
         const content = await fs.promises.readFile(file, {encoding: 'utf8'})
         result.push({file, content})

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ class TestReporter {
   readonly artifact = core.getInput('artifact', {required: false})
   readonly name = core.getInput('name', {required: true})
   readonly path = core.getInput('path', {required: true})
+  readonly ignore = core.getInput('ignore', {required: false})
   readonly pathReplaceBackslashes = core.getInput('path-replace-backslashes', {required: false}) === 'true'
   readonly reporter = core.getInput('reporter', {required: true})
   readonly listSuites = core.getInput('list-suites', {required: true}) as 'all' | 'failed' | 'none'
@@ -102,7 +103,9 @@ class TestReporter {
     // Split path pattern by ',' and optionally convert all backslashes to forward slashes
     // fast-glob (micromatch) always interprets backslashes as escape characters instead of directory separators
     const pathsList = this.path.split(',')
+    const ignoreList = this.ignore.length === 0 ? [] : this.ignore.split(',')
     const pattern = this.pathReplaceBackslashes ? pathsList.map(normalizeFilePath) : pathsList
+    const ignore = this.pathReplaceBackslashes ? ignoreList.map(normalizeFilePath) : ignoreList
 
     const inputProvider = this.artifact
       ? new ArtifactProvider(
@@ -110,11 +113,12 @@ class TestReporter {
           this.artifact,
           this.name,
           pattern,
+          ignore,
           this.context.sha,
           this.context.runId,
           this.token
         )
-      : new LocalFileProvider(this.name, pattern)
+      : new LocalFileProvider(this.name, pattern, ignore)
 
     const parseErrors = this.maxAnnotations > 0
     const trackedFiles = parseErrors ? await inputProvider.listTrackedFiles() : []


### PR DESCRIPTION
## Summary
- add an optional `ignore` input for report path discovery
- pass ignore patterns to `fast-glob` for local files
- apply the same ignore filtering to files read from artifacts
- document the new input and add coverage for skipping `node_modules` reports

## Why
Broad report globs such as `**/test-report.junit.xml` can traverse dependency folders in monorepos. Exposing `fast-glob` ignore patterns lets workflows skip directories like `node_modules` without relying on comma-separated negated paths.

## Validation
- `npm run format-check`
- `npm run build`
- `npm run lint`
- `npm test`
- `npm run package`