### PR TITLE
fix(dotnet-trx): report unmapped outcomes and aborted runs as failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0
 * Feature: Add `list-files` input to control test report file listing https://github.com/dorny/test-reporter/pull/773
 * Feature: Add `summary_file` output with the path to the generated summary in Markdown format https://github.com/dorny/test-reporter/pull/772
+* Fix: `dotnet-trx` reports unmapped test outcomes and aborted test runs as failures https://github.com/dorny/test-reporter/pull/825
 
 ## 3.0.0
 * Feature: Use NodeJS 24 LTS as default runtime https://github.com/dorny/test-reporter/pull/738

--- a/__tests__/dotnet-trx.test.ts
+++ b/__tests__/dotnet-trx.test.ts
@@ -44,6 +44,77 @@ describe('dotnet-trx tests', () => {
     expect(result.result).toBe('success')
   })
 
+  it('reports a test with an outcome the parser does not know as failed', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'dotnet-trx-unknown-outcome.trx')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new DotnetTrxParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+
+    // Passed, Timeout and Inconclusive: only Timeout has no mapping of its own
+    expect(result.tests).toBe(3)
+    expect(result.passed).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.skipped).toBe(1)
+    expect(result.result).toBe('failed')
+
+    // The failure keeps the message VSTest wrote for it
+    const timedOut = result.suites[0].groups[0].tests.find(t => t.name === 'Timed_Out_Test')
+    expect(timedOut?.result).toBe('failed')
+    expect(timedOut?.error?.details).toContain('exceeded execution timeout period')
+  })
+
+  it('reports a run that failed without any failing test', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'dotnet-trx-run-aborted.trx')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new DotnetTrxParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+
+    // The test host crashed: every test that reported passed, but the run did not
+    expect(result.result).toBe('failed')
+    const runSuite = result.suites.find(s => s.name === 'Test run')
+    expect(runSuite?.result).toBe('failed')
+    expect(runSuite?.groups[0].tests[0].error?.details).toContain('Test host process crashed')
+
+    // The run outcome decides, not the RunInfo. A completed run is not a
+    // failure just because a RunInfo carries an error line; some loggers echo
+    // test failures there.
+    const completed = fileContent.replace('<ResultSummary outcome="Failed">', '<ResultSummary outcome="Completed">')
+    const completedResult = await parser.parse(filePath, completed)
+    expect(completedResult.result).toBe('success')
+  })
+
+  it('does not add a run failure when tests already report the failure', async () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'dotnet-trx.trx')
+    const filePath = normalizeFilePath(path.relative(__dirname, fixturePath))
+    const fileContent = fs.readFileSync(fixturePath, {encoding: 'utf8'})
+
+    const opts: ParseOptions = {
+      parseErrors: true,
+      trackedFiles: []
+    }
+
+    const parser = new DotnetTrxParser(opts)
+    const result = await parser.parse(filePath, fileContent)
+
+    // ResultSummary outcome is Failed, but the failing tests are in the report
+    expect(result.result).toBe('failed')
+    expect(result.suites.some(s => s.name === 'Test run')).toBe(false)
+  })
+
   it.each([['dotnet-trx'], ['dotnet-xunitv3']])('matches %s report snapshot', async reportName => {
     const fixturePath = path.join(__dirname, 'fixtures', `${reportName}.trx`)
     const outputPath = path.join(__dirname, '__outputs__', `${reportName}.md`)

--- a/__tests__/fixtures/dotnet-trx-run-aborted.trx
+++ b/__tests__/fixtures/dotnet-trx-run-aborted.trx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRun id="8ba3ff08-3b6f-4c62-b9a1-8d3c2a5c1f02" name="Aborted test run" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2025-06-22T14:20:11.000000+00:00" queuing="2025-06-22T14:20:11.000000+00:00" start="2025-06-22T14:20:11.000000+00:00" finish="2025-06-22T14:20:13.000000+00:00" />
+  <Results>
+    <UnitTestResult executionId="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a03" testId="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1103" testName="DotnetTests.XUnitTests.CalculatorTests.Passing_Test" computerName="CI" duration="00:00:00.0100000" outcome="Passed" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="Passing_Test" storage="dotnettests.xunittests.dll" id="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1103">
+      <Execution id="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a03" />
+      <TestMethod codeBase="DotnetTests.XUnitTests.dll" className="DotnetTests.XUnitTests.CalculatorTests" name="Passing_Test" />
+    </UnitTest>
+  </TestDefinitions>
+  <ResultSummary outcome="Failed">
+    <Counters total="1" executed="1" passed="1" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <RunInfos>
+      <RunInfo computerName="CI" outcome="Error" timestamp="2025-06-22T14:20:13.000000+00:00">
+        <Text>The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.AccessViolationException</Text>
+      </RunInfo>
+    </RunInfos>
+  </ResultSummary>
+</TestRun>

--- a/__tests__/fixtures/dotnet-trx-unknown-outcome.trx
+++ b/__tests__/fixtures/dotnet-trx-unknown-outcome.trx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestRun id="8ba3ff08-3b6f-4c62-b9a1-8d3c2a5c1f01" name="Timed out test run" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2025-06-22T14:17:11.000000+00:00" queuing="2025-06-22T14:17:11.000000+00:00" start="2025-06-22T14:17:11.000000+00:00" finish="2025-06-22T14:17:41.000000+00:00" />
+  <Results>
+    <UnitTestResult executionId="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a01" testId="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1101" testName="DotnetTests.XUnitTests.CalculatorTests.Passing_Test" computerName="CI" duration="00:00:00.0100000" outcome="Passed" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <UnitTestResult executionId="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a02" testId="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1102" testName="DotnetTests.XUnitTests.CalculatorTests.Timed_Out_Test" computerName="CI" duration="00:00:30.0000000" outcome="Timeout" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d">
+      <Output>
+        <ErrorInfo>
+          <Message>Test 'Timed_Out_Test' exceeded execution timeout period.</Message>
+          <StackTrace />
+        </ErrorInfo>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a04" testId="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1104" testName="DotnetTests.XUnitTests.CalculatorTests.Inconclusive_Test" computerName="CI" duration="00:00:00.0100000" outcome="Inconclusive" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="Passing_Test" storage="dotnettests.xunittests.dll" id="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1101">
+      <Execution id="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a01" />
+      <TestMethod codeBase="DotnetTests.XUnitTests.dll" className="DotnetTests.XUnitTests.CalculatorTests" name="Passing_Test" />
+    </UnitTest>
+    <UnitTest name="Timed_Out_Test" storage="dotnettests.xunittests.dll" id="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1102">
+      <Execution id="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a02" />
+      <TestMethod codeBase="DotnetTests.XUnitTests.dll" className="DotnetTests.XUnitTests.CalculatorTests" name="Timed_Out_Test" />
+    </UnitTest>
+    <UnitTest name="Inconclusive_Test" storage="dotnettests.xunittests.dll" id="1c0a2e8f-15f6-4c7a-90ee-6a4b8a0f1104">
+      <Execution id="0a6d5cc4-6b6d-4a3e-9d51-3c9c0c6e2a04" />
+      <TestMethod codeBase="DotnetTests.XUnitTests.dll" className="DotnetTests.XUnitTests.CalculatorTests" name="Inconclusive_Test" />
+    </UnitTest>
+  </TestDefinitions>
+  <ResultSummary outcome="Failed">
+    <Counters total="3" executed="3" passed="1" failed="0" error="0" timeout="1" aborted="0" inconclusive="1" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+  </ResultSummary>
+</TestRun>

--- a/dist/index.js
+++ b/dist/index.js
@@ -58412,6 +58412,24 @@ class DotnetNunitParser {
 
 
 
+// The only place a trx outcome becomes a test result. Outcomes VSTest emits but
+// this parser does not name (Timeout, Aborted, Error, NotRunnable and the rest)
+// must not be reported as passing tests, so they fail like a Failed test does.
+function getOutcomeResult(outcome) {
+    switch (outcome) {
+        // PassedButRunAborted is a test that passed. The aborted run is reported
+        // by getRunFailure instead of by failing tests that did their job.
+        case 'Passed':
+        case 'PassedButRunAborted':
+            return 'success';
+        // Inconclusive is what Assert.Inconclusive produces: a test that opted out
+        case 'NotExecuted':
+        case 'Inconclusive':
+            return 'skipped';
+        default:
+            return 'failed';
+    }
+}
 class TestClass {
     name;
     constructor(name) {
@@ -58431,14 +58449,7 @@ class Test {
         this.error = error;
     }
     get result() {
-        switch (this.outcome) {
-            case 'Passed':
-                return 'success';
-            case 'NotExecuted':
-                return 'skipped';
-            case 'Failed':
-                return 'failed';
-        }
+        return getOutcomeResult(this.outcome);
     }
 }
 class DotnetTrxParser {
@@ -58510,10 +58521,40 @@ class DotnetTrxParser {
             const group = new TestGroupResult(null, tests);
             return new TestSuiteResult(testClass.name, [group]);
         });
+        const runFailure = this.getRunFailure(trx, suites);
+        if (runFailure) {
+            suites.push(runFailure);
+        }
         return new TestRunResult(path, suites, totalTime);
     }
+    // A test run can fail without any single test failing: the test host crashes,
+    // the run is aborted or times out. The run outcome is then the only record of
+    // it, and reporting such a run as successful hides the failure completely.
+    // When tests did fail, they already report it and this adds nothing.
+    getRunFailure(trx, suites) {
+        const summary = trx.TestRun.ResultSummary?.[0];
+        const outcome = summary?.$?.outcome;
+        if (outcome === undefined || outcome === 'Completed' || outcome === 'Passed') {
+            return undefined;
+        }
+        if (suites.some(s => s.result === 'failed')) {
+            return undefined;
+        }
+        const details = (summary?.RunInfos ?? [])
+            .flatMap(infos => infos.RunInfo ?? [])
+            .filter(info => getOutcomeResult(info.$.outcome) === 'failed')
+            .flatMap(info => info.Text ?? [])
+            .join('\n')
+            .trim();
+        const message = `Test run finished with outcome ${outcome} and no failing test`;
+        const error = this.options.parseErrors
+            ? { message, details: details.length > 0 ? details : message }
+            : undefined;
+        const test = new TestCaseResult(`Test run outcome: ${outcome}`, 'failed', 0, error);
+        return new TestSuiteResult('Test run', [new TestGroupResult(null, [test])], 0);
+    }
     getErrorInfo(testResult) {
-        if (testResult.$.outcome !== 'Failed') {
+        if (getOutcomeResult(testResult.$.outcome) !== 'failed') {
             return undefined;
         }
         const output = testResult.Output;

--- a/src/parsers/dotnet-trx/dotnet-trx-parser.ts
+++ b/src/parsers/dotnet-trx/dotnet-trx-parser.ts
@@ -15,6 +15,25 @@ import {
   TestCaseError
 } from '../../test-results.js'
 
+// The only place a trx outcome becomes a test result. Outcomes VSTest emits but
+// this parser does not name (Timeout, Aborted, Error, NotRunnable and the rest)
+// must not be reported as passing tests, so they fail like a Failed test does.
+function getOutcomeResult(outcome: Outcome): TestExecutionResult {
+  switch (outcome) {
+    // PassedButRunAborted is a test that passed. The aborted run is reported
+    // by getRunFailure instead of by failing tests that did their job.
+    case 'Passed':
+    case 'PassedButRunAborted':
+      return 'success'
+    // Inconclusive is what Assert.Inconclusive produces: a test that opted out
+    case 'NotExecuted':
+    case 'Inconclusive':
+      return 'skipped'
+    default:
+      return 'failed'
+  }
+}
+
 class TestClass {
   constructor(readonly name: string) {}
   readonly tests: Test[] = []
@@ -28,15 +47,8 @@ class Test {
     readonly error?: ErrorInfo
   ) {}
 
-  get result(): TestExecutionResult | undefined {
-    switch (this.outcome) {
-      case 'Passed':
-        return 'success'
-      case 'NotExecuted':
-        return 'skipped'
-      case 'Failed':
-        return 'failed'
-    }
+  get result(): TestExecutionResult {
+    return getOutcomeResult(this.outcome)
   }
 }
 
@@ -121,11 +133,46 @@ export class DotnetTrxParser implements TestParser {
       return new TestSuiteResult(testClass.name, [group])
     })
 
+    const runFailure = this.getRunFailure(trx, suites)
+    if (runFailure) {
+      suites.push(runFailure)
+    }
+
     return new TestRunResult(path, suites, totalTime)
   }
 
+  // A test run can fail without any single test failing: the test host crashes,
+  // the run is aborted or times out. The run outcome is then the only record of
+  // it, and reporting such a run as successful hides the failure completely.
+  // When tests did fail, they already report it and this adds nothing.
+  private getRunFailure(trx: TrxReport, suites: TestSuiteResult[]): TestSuiteResult | undefined {
+    const summary = trx.TestRun.ResultSummary?.[0]
+    const outcome = summary?.$?.outcome
+    if (outcome === undefined || outcome === 'Completed' || outcome === 'Passed') {
+      return undefined
+    }
+    if (suites.some(s => s.result === 'failed')) {
+      return undefined
+    }
+
+    const details = (summary?.RunInfos ?? [])
+      .flatMap(infos => infos.RunInfo ?? [])
+      .filter(info => getOutcomeResult(info.$.outcome) === 'failed')
+      .flatMap(info => info.Text ?? [])
+      .join('\n')
+      .trim()
+
+    const message = `Test run finished with outcome ${outcome} and no failing test`
+    const error: TestCaseError | undefined = this.options.parseErrors
+      ? {message, details: details.length > 0 ? details : message}
+      : undefined
+
+    const test = new TestCaseResult(`Test run outcome: ${outcome}`, 'failed', 0, error)
+    return new TestSuiteResult('Test run', [new TestGroupResult(null, [test])], 0)
+  }
+
   private getErrorInfo(testResult: UnitTestResult): ErrorInfo | undefined {
-    if (testResult.$.outcome !== 'Failed') {
+    if (getOutcomeResult(testResult.$.outcome) !== 'failed') {
       return undefined
     }
 

--- a/src/parsers/dotnet-trx/dotnet-trx-types.ts
+++ b/src/parsers/dotnet-trx/dotnet-trx-types.ts
@@ -6,6 +6,25 @@ export interface TestRun {
   Times: Times[]
   Results?: Results[]
   TestDefinitions?: TestDefinitions[]
+  ResultSummary?: ResultSummary[]
+}
+
+export interface ResultSummary {
+  $: {
+    outcome: Outcome
+  }
+  RunInfos?: RunInfos[]
+}
+
+export interface RunInfos {
+  RunInfo?: RunInfo[]
+}
+
+export interface RunInfo {
+  $: {
+    outcome: Outcome
+  }
+  Text?: string[]
 }
 
 export interface Times {
@@ -57,4 +76,7 @@ export interface ErrorInfo {
   StackTrace: string[]
 }
 
-export type Outcome = 'Passed' | 'NotExecuted' | 'Failed'
+// VSTest writes any of its TestOutcome values here. Besides the three named
+// below it can emit Timeout, Aborted, Error, NotRunnable, Inconclusive and
+// others. An outcome without a mapping is treated as a failure, never as a pass.
+export type Outcome = 'Passed' | 'NotExecuted' | 'Failed' | (string & {})


### PR DESCRIPTION
Fixes #401.

## Problem

`dotnet-trx` maps three VSTest outcomes:

```ts
export type Outcome = 'Passed' | 'NotExecuted' | 'Failed'
```

VSTest writes more than three on `<UnitTestResult>`. The fixture
`SonarSource/sonar-dotnet` keeps under the name `valid.trx` has unit test results
with `Timeout`, `Aborted`, `Error`, `Inconclusive`, `NotRunnable`, `Blocked`,
`PassedButRunAborted`, `Warning` and `Completed`, and `jenkinsci/mstest-plugin`
keeps `mstest_vs_2012_timeout.trx`. Any outcome outside the three falls out of the
`switch` in `Test.result` and becomes `undefined`. Every aggregation in
`test-results.ts` then asks `some(t => t.result === 'failed')`, so `undefined`
counts as a pass.

With the fixture this PR adds (`Passed`, `Timeout`, `Inconclusive`), `main` today
renders:

```
![Tests passed successfully](https://img.shields.io/badge/tests-1%20passed-success)
**3** tests were completed in **30s** with **1** passed, **0** failed and **0** skipped.
 Inconclusive_Test
✅ Passing_Test
 Timed_Out_Test
```

Three tests, and the counts add up to one. The check run conclusion is `success`
and `fail-on-error` never sees a failure, so a timed out test does not block a
merge.

There is a second case, which is #401. A run can fail with no failing test at
all: the test host crashes, and VSTest writes `<ResultSummary outcome="Failed">`
with a `RunInfo` explaining why. The parser does not read `ResultSummary`, so the
run is reported as fully passing.

## Solution

* One mapping for outcomes, with a `default` that fails. `Passed` and
  `PassedButRunAborted` map to success, `NotExecuted` and `Inconclusive` to
  skipped, everything else to failed. This is what `golang-json` already does,
  where anything that is not `pass` or `skip` is a failure, and what #155
  settled for `jest-junit`: a test that did not run is a failure, not silence.
* The same mapping decides whether `ErrorInfo` is collected, so a test that timed
  out or errored keeps its message instead of losing it.
* `ResultSummary` and `RunInfos` added to the trx types. A run whose outcome is
  not `Completed` or `Passed`, and that has no failing test, gets one failing
  entry named `Test run outcome: <outcome>` carrying the `RunInfo` text. When
  tests did fail, they already report the failure and nothing is added.

Two of the mappings are deliberate rather than mechanical. `Inconclusive` maps to
skipped because `Assert.Inconclusive` is how a .NET test opts out at runtime, and
failing those would change behaviour for a common pattern. `PassedButRunAborted`
maps to success because the test itself passed; the aborted run is reported by
the run level rule instead.

The run level rule keys on `ResultSummary/@outcome` and not on `RunInfo` entries,
because loggers echo ordinary test failures into `RunInfo`. This repository's own
`__tests__/fixtures/dotnet-trx.trx` carries five `RunInfo outcome="Error"` lines
that are xUnit `[FAIL]` console output. A test covers that case: a run whose
summary says `Completed` stays a success even with an error `RunInfo`.

## Behaviour change

Some reports that are green today turn red. A project whose `.trx` contains
timed out, aborted, blocked or errored tests, or whose test host crashes, starts
seeing failures it did not see before. There is no new input to opt out of it,
since `fail-on-error: false` already keeps the check run green for a project that
wants that.

`dart-json` has the same shape, where `TestCase.result` returns `undefined` if a
test never reports `testDone`. I left it out to keep this to one reporter, and
I am happy to follow up with the same fix if you want it.

## Tests

Three cases in `__tests__/dotnet-trx.test.ts` and two fixtures:

* `dotnet-trx-unknown-outcome.trx` with `Passed`, `Timeout` and `Inconclusive`
  gives 1 passed, 1 failed, 1 skipped, run result `failed`, and the timed out
  test keeps its message.
* `dotnet-trx-run-aborted.trx` is #401's case: one passing test,
  `ResultSummary outcome="Failed"`, `RunInfo outcome="Error"`. The run result is
  `failed` and the crash text reaches the report. The same file with
  `outcome="Completed"` stays a success.
* `dotnet-trx.trx`, the existing fixture, is still `failed` and gets no
  `Test run` entry, because its own failing tests already report it.

## Verification

* `npm test`: 160 passed, 18 suites, 30 snapshots, no snapshot updated.
* `npm run lint` and `npm run format-check` pass.
* `npm run build && npm run package` leaves `git diff dist/` empty, so
  `check-dist` is satisfied.

Workflow runs on outside contributors' PRs here need a maintainer to approve
them, so the checks on this PR may stay empty. The numbers above come from a
local run at this commit.
